### PR TITLE
Add a check in _parse_type_from_version

### DIFF
--- a/pyasic/miners/miner_factory.py
+++ b/pyasic/miners/miner_factory.py
@@ -569,7 +569,12 @@ class MinerFactory(metaclass=Singleton):
         # if all that fails, check the Description to see if it is a whatsminer
         if version.get("Description") and ("whatsminer" in version.get("Description")):
             api = "BTMiner"
-
+        
+        # If version does not exist in the keys, return None (resulting in Unknown).
+        # Prevents halting on suspended miners that aren't returning valid information.
+        if "VERSION" not in version.keys():
+            return None, None, None
+        
         # check for avalonminers
         if version["VERSION"][0].get("PROD"):
             _data = version["VERSION"][0]["PROD"].split("-")


### PR DESCRIPTION
If a miner doesn't return a VERSION field, then _parse_type_from_version fails and halts. Added a check to return None in this case (resulting in Unknown miner). This occurs to some Whatsminers when they are placed in suspend.