### PR TITLE
use `None` instead of `-1` for temps and wattages

### DIFF
--- a/pyasic/data/__init__.py
+++ b/pyasic/data/__init__.py
@@ -41,8 +41,8 @@ class HashBoard:
 
     slot: int = 0
     hashrate: float = 0.0
-    temp: int = -1
-    chip_temp: int = -1
+    temp: int = None
+    chip_temp: int = None
     chips: int = 0
     expected_chips: int = 0
     missing: bool = True
@@ -56,7 +56,7 @@ class Fan:
         speed: The speed of the fan.
     """
 
-    speed: int = -1
+    speed: int = None
 
 
 @dataclass
@@ -115,11 +115,11 @@ class MinerData:
     hashboards: List[HashBoard] = field(default_factory=list)
     ideal_hashboards: int = 1
     temperature_avg: int = field(init=False)
-    env_temp: float = -1.0
-    wattage: int = -1
-    wattage_limit: int = -1
+    env_temp: float = None
+    wattage: int = None
+    wattage_limit: int = None
     fans: List[Fan] = field(default_factory=list)
-    fan_psu: int = -1
+    fan_psu: int = None
     total_chips: int = field(init=False)
     ideal_chips: int = 1
     percent_ideal_chips: float = field(init=False)

--- a/pyasic/data/__init__.py
+++ b/pyasic/data/__init__.py
@@ -255,7 +255,7 @@ class MinerData:
         total_temp = 0
         temp_count = 0
         for hb in self.hashboards:
-            if hb.temp and not hb.temp == -1:
+            if hb.temp and not hb.temp == None:
                 total_temp += hb.temp
                 temp_count += 1
         if not temp_count > 0:
@@ -268,7 +268,7 @@ class MinerData:
 
     @property
     def efficiency(self):  # noqa - Skip PyCharm inspection
-        if self.hashrate == 0 or self.wattage == -1:
+        if self.hashrate == 0 or self.wattage == None:
             return 0
         return round(self.wattage / self.hashrate)
 

--- a/pyasic/load/__init__.py
+++ b/pyasic/load/__init__.py
@@ -149,10 +149,10 @@ class _MinerPhaseBalancer:
                 not self.miners[data_point.ip]["shutdown"]
             ):
                 # cant do anything with it so need to find a semi-accurate power limit
-                if not data_point.wattage_limit == -1:
+                if not data_point.wattage_limit == None:
                     self.miners[data_point.ip]["max"] = int(data_point.wattage_limit)
                     self.miners[data_point.ip]["min"] = int(data_point.wattage_limit)
-                elif not data_point.wattage == -1:
+                elif not data_point.wattage == None:
                     self.miners[data_point.ip]["max"] = int(data_point.wattage)
                     self.miners[data_point.ip]["min"] = int(data_point.wattage)
 

--- a/pyasic/miners/antminer/hiveon/X9/T9.py
+++ b/pyasic/miners/antminer/hiveon/X9/T9.py
@@ -58,7 +58,7 @@ class HiveonT9(Hiveon, T9):
             hashrate = 0
             chips = 0
             for chipset in board_map[board]:
-                if hashboard.chip_temp == -1:
+                if hashboard.chip_temp == None:
                     try:
                         hashboard.board_temp = api_stats["STATS"][1][f"temp{chipset}"]
                         hashboard.chip_temp = api_stats["STATS"][1][f"temp2_{chipset}"]


### PR DESCRIPTION
this way it's easier for other tools like HomeAssistant to understand if the temperature is really negative or not available

HomeAssistant for example shows `Unknown` when the variable is `None`, which is nicer than `-1`