### PR TITLE
hotfix: fix epic api error handling

### DIFF
--- a/pyasic/web/epic.py
+++ b/pyasic/web/epic.py
@@ -23,21 +23,6 @@ from pyasic import settings
 from pyasic.web import BaseWebAPI
 from pyasic.errors import APIError, APIWarning
 
-
-class ePICerror(Exception):
-    def __init__(self, *args):
-        if args:
-            self.message = args[0]
-        else:
-            self.message = None
-
-    def __str__(self):
-        if self.message:
-            return f"{self.message}"
-        else:
-            return "Incorrect API parameters."
-
-
 class ePICWebAPI(BaseWebAPI):
     def __init__(self, ip: str) -> None:
         super().__init__(ip)
@@ -46,32 +31,28 @@ class ePICWebAPI(BaseWebAPI):
         self.token = None
 
     async def send_command(
-        self,
-        command: Union[str, bytes],
-        ignore_errors: bool = False,
-        allow_warning: bool = True,
-        **parameters: Union[str, int, bool],
+            self,
+            command: Union[str, bytes],
+            ignore_errors: bool = False,
+            allow_warning: bool = True,
+            post: bool = False,
+            **parameters: Union[str, int, bool],
     ) -> dict:
-        async with httpx.AsyncClient() as client:
-            is_get = False
-            for i in range(settings.get("get_data_retries", 1)):
+        if post or parameters != {}:
+            post = True
+        
+        async with httpx.AsyncClient(transport=settings.transport()) as client:
+            for i in range(settings.get("get_data_retries", 1) + 1):
                 try:
-                    if parameters.get("post"):
-                        parameters.pop("post")
-                        epic_param = {"param": parameters.get("parameters"), "password": self.pwd}
+                    if post:
+                        epic_param = {"param": parameters.get("parameters"),
+                                      "password": self.pwd}
                         response = await client.post(
                             f"http://{self.ip}:4028/{command}",
                             timeout=5,
                             json=epic_param,
                         )
-                    elif not parameters == {}:
-                        response = await client.post(
-                            f"http://{self.ip}:4028/{command}",
-                            timeout=5,
-                            json=parameters,
-                        )
                     else:
-                        is_get = True
                         response = await client.get(
                             f"http://{self.ip}:4028/{command}",
                             timeout=5,
@@ -82,17 +63,14 @@ class ePICWebAPI(BaseWebAPI):
                     json_data = response.json()
                     if json_data:
                         # The API can return a fail status if the miner cannot return the requested data. Catch this and pass
-                        if "result" in json_data and json_data["result"] is False and is_get:
-                            raise ePICerror(json_data["error"])
+                        if "result" in json_data and json_data["result"] is False and not post:
+                            if not i > settings.get("get_data_retries", 1):
+                                continue
+                            if not ignore_errors:
+                                raise APIError(json_data["error"])
                         return json_data
                     return {"success": True}
-                except httpx.HTTPError:
-                    pass
-                except json.JSONDecodeError:
-                    pass
-                except ePICerror as e:
-                    pass
-                except AttributeError:
+                except (httpx.HTTPError, json.JSONDecodeError, AttributeError):
                     pass
 
     async def multicommand(

--- a/pyasic/web/epic.py
+++ b/pyasic/web/epic.py
@@ -24,6 +24,20 @@ from pyasic.web import BaseWebAPI
 from pyasic.errors import APIError, APIWarning
 
 
+class ePICerror(Exception):
+    def __init__(self, *args):
+        if args:
+            self.message = args[0]
+        else:
+            self.message = None
+
+    def __str__(self):
+        if self.message:
+            return f"{self.message}"
+        else:
+            return "Incorrect API parameters."
+
+
 class ePICWebAPI(BaseWebAPI):
     def __init__(self, ip: str) -> None:
         super().__init__(ip)
@@ -68,13 +82,15 @@ class ePICWebAPI(BaseWebAPI):
                     json_data = response.json()
                     if json_data:
                         # The API can return a fail status if the miner cannot return the requested data. Catch this and pass
-                        if "result" in json_data and json_data["result"] is False and is_get and not ignore_errors:
-                            raise APIError(json_data["error"])
+                        if "result" in json_data and json_data["result"] is False and is_get:
+                            raise ePICerror(json_data["error"])
                         return json_data
                     return {"success": True}
                 except httpx.HTTPError:
                     pass
                 except json.JSONDecodeError:
+                    pass
+                except ePICerror as e:
                     pass
                 except AttributeError:
                     pass


### PR DESCRIPTION
Sorry for this being missed, as we made that one change to respect the ignore_errors.

I might not have explained the API behaviour:

The ePIC REST API will always return. If the data was available it will return with the requested data, if for some reason internally there was a "Lock" on the data or it was currently being updated, the API will return with a "result: false" and an indication of what data was not available. 

In this scenario, 9.999/10 times the solution is just to re-request the data, which is handled in this case. 

Acknowledging this as a APIError seems to crash pyasic-web, so my proposed solution is to make this a "ePIC Error" type, which will just retry the fetch based on the retry count. That should cover all cases