### PR TITLE
send_config support for ePIC UMC

### DIFF
--- a/pyasic/config/fans.py
+++ b/pyasic/config/fans.py
@@ -50,7 +50,7 @@ class FanModeNormal(MinerConfigValue):
         return {"temp_control": {"mode": "auto"}}
 
     def as_epic(self) -> dict:
-        return {"fan_control": {"mode": "Auto", "speed": self.speed}}
+        return {"fan_control": {"mode": "Auto", "speed": 100}}
 
 
 @dataclass

--- a/pyasic/config/fans.py
+++ b/pyasic/config/fans.py
@@ -33,6 +33,9 @@ class FanModeNormal(MinerConfigValue):
     def as_bosminer(self) -> dict:
         return {"temp_control": {"mode": "auto"}}
 
+    def as_epic(self) -> dict:
+        return {"fan_control": {"mode": "Auto", "speed": self.speed}}
+
 
 @dataclass
 class FanModeManual(MinerConfigValue):
@@ -66,6 +69,9 @@ class FanModeManual(MinerConfigValue):
             "temp_control": {"mode": "manual"},
             "fan_control": {"min_fans": self.minimum_fans, "speed": self.speed},
         }
+
+    def as_epic(self) -> dict:
+        return {"fan_control": {"mode": "Manual", "speed": self.speed}}
 
 
 @dataclass

--- a/pyasic/config/mining.py
+++ b/pyasic/config/mining.py
@@ -33,6 +33,9 @@ class MiningModeNormal(MinerConfigValue):
     def as_wm(self) -> dict:
         return {"mode": self.mode}
 
+    def as_epic(self) -> dict:
+        return {"ptune": {"enabled": False}}
+
 
 @dataclass
 class MiningModeSleep(MinerConfigValue):
@@ -47,6 +50,9 @@ class MiningModeSleep(MinerConfigValue):
 
     def as_wm(self) -> dict:
         return {"mode": self.mode}
+
+    def as_epic(self) -> dict:
+        return {"ptune": False, "algo": "Sleep", "target": 0}
 
 
 @dataclass
@@ -112,6 +118,28 @@ class MiningModeHashrateTune(MinerConfigValue):
     def as_am_modern(self) -> dict:
         return {"miner-mode": "0"}
 
+    def as_epic(self) -> dict:
+        return {"ptune": {"enabled": True, "algo": "ChipTune", "target": self.hashrate}}
+
+
+@dataclass
+class MiningModeVoltageTune(MinerConfigValue):
+    mode: str = field(init=False, default="voltage_tuning")
+    hashrate: int = None
+
+    @classmethod
+    def from_dict(cls, dict_conf: Union[dict, None]) -> "MiningModeVoltageTune":
+        return cls(dict_conf.get("hashrate"))
+
+    def as_epic(self) -> dict:
+        return {
+            "ptune": {
+                "enabled": True,
+                "algo": "VoltageOptimizer",
+                "target": self.hashrate,
+            }
+        }
+
 
 @dataclass
 class ManualBoardSettings(MinerConfigValue):
@@ -153,6 +181,7 @@ class MiningModeConfig(MinerConfigOption):
     sleep = MiningModeSleep
     power_tuning = MiningModePowerTune
     hashrate_tuning = MiningModeHashrateTune
+    voltage_tuning = MiningModeVoltageTune
     manual = MiningModeManual
 
     @classmethod
@@ -195,7 +224,7 @@ class MiningModeConfig(MinerConfigOption):
                     web_conf["PerpetualTune"]["Algorithm"].get("VoltageOptimizer")
                     is not None
                 ):
-                    return cls.hashrate_tuning(
+                    return cls.voltage_tuning(
                         web_conf["PerpetualTune"]["Algorithm"]["VoltageOptimizer"][
                             "Target"
                         ]

--- a/pyasic/config/pools.py
+++ b/pyasic/config/pools.py
@@ -102,7 +102,7 @@ class Pool(MinerConfigValue):
         if user_suffix is not None:
             return {
                 "pool": self.url,
-                "login": f"{self.user}-{user_suffix}",
+                "login": f"{self.user}{user_suffix}",
                 "password": self.password,
             }
         return {"pool": self.url, "login": self.user, "password": self.password}
@@ -251,7 +251,7 @@ class PoolGroup(MinerConfigValue):
             if self.quota is not None:
                 conf["quota"] = self.quota
             return conf
-        return {"name": "Group", "pool": []}
+        return {"name": self.name, "pool": []}
 
     @classmethod
     def from_dict(cls, dict_conf: Union[dict, None]) -> "PoolGroup":

--- a/pyasic/config/pools.py
+++ b/pyasic/config/pools.py
@@ -98,6 +98,15 @@ class Pool(MinerConfigValue):
             }
         return {"url": self.url, "user": self.user, "password": self.password}
 
+    def as_epic(self, user_suffix: str = None):
+        if user_suffix is not None:
+            return {
+                "pool": self.url,
+                "login": f"{self.user}-{user_suffix}",
+                "password": self.password,
+            }
+        return {"pool": self.url, "login": self.user, "password": self.password}
+
     @classmethod
     def from_dict(cls, dict_conf: Union[dict, None]) -> "Pool":
         return cls(
@@ -225,6 +234,17 @@ class PoolGroup(MinerConfigValue):
             return conf
         return {"name": "Group", "pool": []}
 
+    def as_epic(self, user_suffix: str = None) -> dict:
+        if len(self.pools) > 0:
+            conf = {
+                "name": self.name,
+                "pool": [pool.as_epic(user_suffix=user_suffix) for pool in self.pools],
+            }
+            if self.quota is not None:
+                conf["quota"] = self.quota
+            return conf
+        return {"name": "Group", "pool": []}
+
     @classmethod
     def from_dict(cls, dict_conf: Union[dict, None]) -> "PoolGroup":
         cls_conf = {}
@@ -336,6 +356,11 @@ class PoolConfig(MinerConfigValue):
                 "group": [g.as_bosminer(user_suffix=user_suffix) for g in self.groups]
             }
         return {"group": [PoolGroup().as_bosminer()]}
+
+    def as_epic(self, user_suffix: str = None) -> dict:
+        if len(self.groups) > 0:
+            return {"pools": [g.as_epic(user_suffix=user_suffix) for g in self.groups]}
+        return {"pools": [PoolGroup().as_epic()]}
 
     def as_bos_grpc(self, user_suffix: str = None) -> dict:
         return {}

--- a/pyasic/config/temperature.py
+++ b/pyasic/config/temperature.py
@@ -39,6 +39,17 @@ class TemperatureConfig(MinerConfigValue):
             temp_cfg["dangerous_temp"] = self.danger
         return {"temp_control": temp_cfg}
 
+    def as_epic(self) -> dict:
+        temp_cfg = {}
+        if self.target is not None:
+            temp_cfg["target_temp"] = self.target
+        else:
+            ## If no target_temp setm, auto set to -15 of shutdown
+            temp_cfg["target_temp"] = self.hot - 15.0
+        if self.hot is not None:
+            temp_cfg["hot_temp"] = self.hot
+        return {"temp_control": temp_cfg}
+
     @classmethod
     def from_dict(cls, dict_conf: Union[dict, None]) -> "TemperatureConfig":
         return cls(

--- a/pyasic/config/temperature.py
+++ b/pyasic/config/temperature.py
@@ -44,7 +44,7 @@ class TemperatureConfig(MinerConfigValue):
         if self.target is not None:
             temp_cfg["target_temp"] = self.target
         else:
-            ## If no target_temp setm, auto set to -15 of shutdown
+            ## If no target_temp set, autoset to -15 of shutdown
             temp_cfg["target_temp"] = self.hot - 15.0
         if self.hot is not None:
             temp_cfg["hot_temp"] = self.hot

--- a/pyasic/config/temperature.py
+++ b/pyasic/config/temperature.py
@@ -45,9 +45,9 @@ class TemperatureConfig(MinerConfigValue):
             temp_cfg["target_temp"] = self.target
         else:
             ## If no target_temp set, autoset to -15 of shutdown
-            temp_cfg["target_temp"] = self.hot - 15.0
+            temp_cfg["target_temp"] = self.dangerous_temp - 15.0
         if self.hot is not None:
-            temp_cfg["hot_temp"] = self.hot
+            temp_cfg["dangerous_temp"] = self.dangerous_temp
         return {"temp_control": temp_cfg}
 
     @classmethod
@@ -70,11 +70,11 @@ class TemperatureConfig(MinerConfigValue):
 
     @classmethod
     def from_epic(cls, web_conf: dict) -> "TemperatureConfig":
-        dangerous_temp = None
+        hot_temp = None
         try:
-            hot_temp = web_conf["Misc"]["Shutdown Temp"]
+            dangerous_temp = web_conf["Misc"]["Shutdown Temp"]
         except KeyError:
-            hot_temp = None
+            dangerous_temp = None
         # Need to do this in two blocks to avoid KeyError if one is missing
         try:
             target_temp = web_conf["Fans"]["Fan Mode"]["Auto"]["Target Temperature"]

--- a/pyasic/miners/backends/epic.py
+++ b/pyasic/miners/backends/epic.py
@@ -121,7 +121,9 @@ class ePIC(BaseMiner):
 
         try:
             # Temps
-            data = await self.web.set_shutdown_temp(conf["temp_control"]["hot_temp"])
+            data = await self.web.set_shutdown_temp(
+                conf["temp_control"]["dangerous_temp"]
+            )
             # Fans
             if conf["fan_control"]["mode"] == "Manual":
                 data = await self.web.set_fan(

--- a/pyasic/web/epic.py
+++ b/pyasic/web/epic.py
@@ -50,13 +50,11 @@ class ePICWebAPI(BaseWebAPI):
                             "param": parameters.get("parameters"),
                             "password": self.pwd,
                         }
-                        print(epic_param)
                         response = await client.post(
                             f"http://{self.ip}:4028/{command}",
                             timeout=5,
                             json=epic_param,
                         )
-                        print(response.text)
                     else:
                         response = await client.get(
                             f"http://{self.ip}:4028/{command}",

--- a/pyasic/web/epic.py
+++ b/pyasic/web/epic.py
@@ -50,11 +50,13 @@ class ePICWebAPI(BaseWebAPI):
                             "param": parameters.get("parameters"),
                             "password": self.pwd,
                         }
+                        print(epic_param)
                         response = await client.post(
                             f"http://{self.ip}:4028/{command}",
                             timeout=5,
                             json=epic_param,
                         )
+                        print(response.text)
                     else:
                         response = await client.get(
                             f"http://{self.ip}:4028/{command}",
@@ -105,6 +107,23 @@ class ePICWebAPI(BaseWebAPI):
 
     async def start_mining(self) -> dict:
         return await self.send_command("miner", post=True, parameters="Autostart")
+
+    async def set_shutdown_temp(self, params: int) -> dict:
+        return await self.send_command("shutdowntemp", post=True, parameters=params)
+
+    async def set_fan(self, params: dict) -> dict:
+        return await self.send_command("fanspeed", post=True, parameters=params)
+
+    async def set_ptune_enable(self, params: bool) -> dict:
+        return await self.send_command("perpetualtune", post=True, parameters=params)
+
+    async def set_ptune_algo(self, params: dict) -> dict:
+        return await self.send_command(
+            "perpetualtune/algo", post=True, parameters=params
+        )
+
+    async def set_pools(self, params: dict) -> dict:
+        return await self.send_command("coin", post=True, parameters=params)
 
     async def summary(self):
         return await self.send_command("summary")


### PR DESCRIPTION
Initial go at adding support for the MinerConfig for ePIC UMCs. 

The support is preliminary and will most likely require additional changes for error handling, but basic functionality is now supported and the UMC can be configured from pyasic.

Modes are matched to the "closest match" for the most part in order to try and keep it consistent. My initial thought was to add mode modes however my concern and thought is that a user most likely wants to create a singular config and push it to multiple models (including different machines (Bitmain, Whatsminer, etc) and FWs) so may be destructive to that mode creating multiple modes that wouldn't be supported. 