### PR TITLE
Fix vnish wattage dimension

### DIFF
--- a/pyasic/miners/backends/vnish.py
+++ b/pyasic/miners/backends/vnish.py
@@ -167,7 +167,7 @@ class VNish(BMMiner):
         if web_summary is not None:
             try:
                 wattage = web_summary["miner"]["power_usage"]
-                wattage = round(wattage * 1000)
+                wattage = round(wattage)
                 return wattage
             except KeyError:
                 pass


### PR DESCRIPTION
Update backend vnish.py

Vnish miner view:

![image](https://github.com/UpstreamData/pyasic/assets/29798773/d404219c-0adf-4ed6-acc4-7e6562f84f54)

1) Before fix - `wattage` and `wattage_limit` metrics in different dimensions
2) After fix - `wattage` and `wattage_limit` metrics in same dimensions

For some other miner providers the metrics are the same dimensions.

Thanks for this project, you made my day!