### PR TITLE
Update btminer.py _send_bytes to include port

### DIFF
--- a/pyasic/rpc/btminer.py
+++ b/pyasic/rpc/btminer.py
@@ -276,7 +276,7 @@ class BTMinerRPCAPI(BaseMinerRPCAPI):
 
         logging.debug(f"{self} - (Send Privileged Command) - Sending")
         try:
-            data = await self._send_bytes(enc_command, timeout)
+            data = await self._send_bytes(enc_command, self.port, timeout)
         except (asyncio.CancelledError, asyncio.TimeoutError):
             if ignore_errors:
                 return {}


### PR DESCRIPTION
Port was missing from the _send_bytes call in _send_privileged_command, resulting in timeout = 10 being passed as the port.

This resulted in failing write commands on WM