### PR TITLE
feat: Add update firmware for ePIC miner

### DIFF
--- a/pyasic/miners/backends/epic.py
+++ b/pyasic/miners/backends/epic.py
@@ -16,8 +16,8 @@
 
 import logging
 import aiofiles
-import hashlib 
-import aiohttp 
+import hashlib
+import aiohttp
 from pathlib import Path
 from typing import List, Optional
 

--- a/pyasic/miners/backends/epic.py
+++ b/pyasic/miners/backends/epic.py
@@ -451,7 +451,7 @@ class ePIC(ePICFirmware):
                 return pool_data
         except LookupError:
             pass
-    
+
     async def upgrade_firmware(self, file: Path | str, keep_settings: bool = True) -> bool:
 
         """

--- a/pyasic/miners/backends/epic.py
+++ b/pyasic/miners/backends/epic.py
@@ -14,6 +14,11 @@
 #  limitations under the License.                                              -
 # ------------------------------------------------------------------------------
 
+import logging
+import aiofiles
+import hashlib 
+import aiohttp 
+from pathlib import Path
 from typing import List, Optional
 
 from pyasic.config import MinerConfig
@@ -450,3 +455,70 @@ class ePIC(ePICFirmware):
                 return pool_data
         except LookupError:
             pass
+
+    async def upgrade_firmware(self, file: Path, keepsettings: bool, password: str):
+
+        """
+        Upgrade the firmware of the ePIC miner device.
+
+        Args:
+            file (Path): The local file path of the firmware to be uploaded.
+            keepsettings (bool): Whether to keep the current settings after the update.
+            password (str): The password for authentication.
+
+        Returns:
+            str: Confirmation message after upgrading the firmware.
+        """
+        try:
+            logging.info("Starting firmware upgrade process for ePIC miner.")
+
+            if not file:
+                raise ValueError("File location must be provided for firmware upgrade.")
+
+            # calculate the SHA256 checksum of the firmware file
+            sha256_hash = hashlib.sha256()
+            async with aiofiles.open(file, "rb") as f:
+                while chunk := await f.read(8192):
+                    sha256_hash.update(chunk)
+            checksum = sha256_hash.hexdigest()
+
+            # prepare the multipart/form-data request
+            form_data = aiohttp.FormData()
+            form_data.add_field('checksum', checksum)
+            form_data.add_field('keepsettings', str(keepsettings).lower())
+            form_data.add_field('password', password)
+            form_data.add_field('update.zip', open(file, 'rb'), filename='update.zip')
+
+            # Send the POST request to the ePIC miner device
+            async with aiohttp.ClientSession() as session:
+                async with session.post(f"http://{self.ip}:{self.port}/systemupdate", data=form_data) as response:
+                    if response.status == 200:
+                        result = await response.json()
+                        if result.get("result"):
+                            logging.info("Firmware upgrade process completed successfully for ePIC miner.")
+                            return "Firmware upgrade completed successfully."
+                        else:
+                            error = result.get("error", "Unknown error")
+                            logging.error(f"Firmware upgrade failed: {error}")
+                            raise Exception(f"Firmware upgrade failed: {error}")
+                    else:
+                        logging.error(f"Firmware upgrade failed with status code: {response.status}")
+                        raise Exception(f"Firmware upgrade failed with status code: {response.status}")
+
+        except FileNotFoundError as e:
+            logging.error(f"File not found during the firmware upgrade process: {e}")
+            raise
+        except ValueError as e:
+            logging.error(
+                f"Validation error occurred during the firmware upgrade process: {e}"
+            )
+            raise
+        except OSError as e:
+            logging.error(f"OS error occurred during the firmware upgrade process: {e}")
+            raise
+        except Exception as e:
+            logging.error(
+                f"An unexpected error occurred during the firmware upgrade process: {e}",
+                exc_info=True,
+            )
+            raise

--- a/pyasic/miners/backends/epic.py
+++ b/pyasic/miners/backends/epic.py
@@ -490,20 +490,19 @@ class ePIC(ePICFirmware):
             form_data.add_field('update.zip', open(file, 'rb'), filename='update.zip')
 
             # Send the POST request to the ePIC miner device
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"http://{self.ip}:{self.port}/systemupdate", data=form_data) as response:
-                    if response.status == 200:
-                        result = await response.json()
-                        if result.get("result"):
-                            logging.info("Firmware upgrade process completed successfully for ePIC miner.")
-                            return "Firmware upgrade completed successfully."
-                        else:
-                            error = result.get("error", "Unknown error")
-                            logging.error(f"Firmware upgrade failed: {error}")
-                            raise Exception(f"Firmware upgrade failed: {error}")
+            async with self.web.post(f"http://{self.ip}:{self.port}/systemupdate", data=form_data) as response:
+                if response.status == 200:
+                    result = await response.json()
+                    if result.get("result"):
+                        logging.info("Firmware upgrade process completed successfully for ePIC miner.")
+                        return "Firmware upgrade completed successfully."
                     else:
-                        logging.error(f"Firmware upgrade failed with status code: {response.status}")
-                        raise Exception(f"Firmware upgrade failed with status code: {response.status}")
+                        error = result.get("error", "Unknown error")
+                        logging.error(f"Firmware upgrade failed: {error}")
+                        raise Exception(f"Firmware upgrade failed: {error}")
+                else:
+                    logging.error(f"Firmware upgrade failed with status code: {response.status}")
+                    raise Exception(f"Firmware upgrade failed with status code: {response.status}")
 
         except FileNotFoundError as e:
             logging.error(f"File not found during the firmware upgrade process: {e}")

--- a/pyasic/web/epic.py
+++ b/pyasic/web/epic.py
@@ -19,6 +19,10 @@ import json
 from typing import Any
 
 import httpx
+import aiofiles
+import aiohttp
+import hashlib
+from pathlib import Path
 
 from pyasic import settings
 from pyasic.errors import APIError
@@ -46,6 +50,14 @@ class ePICWebAPI(BaseWebAPI):
         async with httpx.AsyncClient(transport=settings.transport()) as client:
             for retry_cnt in range(settings.get("get_data_retries", 1)):
                 try:
+                    if parameters.get("form") is not None:
+                        form_data = parameters["form"]
+                        form_data.add_field('password', self.pwd)
+                        response = await client.post(
+                            f"http://{self.ip}:{self.port}/{command}",
+                            timeout=5,
+                            data=form_data,
+                        )
                     if post:
                         response = await client.post(
                             f"http://{self.ip}:{self.port}/{command}",
@@ -135,3 +147,22 @@ class ePICWebAPI(BaseWebAPI):
 
     async def capabilities(self) -> dict:
         return await self.send_command("capabilities")
+
+    async def system_update(self, file: Path | str, keep_settings: bool = True):
+        """Perform a system update by uploading a firmware file and sending a 
+        command to initiate the update."""
+
+        # calculate the SHA256 checksum of the firmware file
+        sha256_hash = hashlib.sha256()
+        async with aiofiles.open(str(file), "rb") as f:
+            while chunk := await f.read(8192):
+                sha256_hash.update(chunk)
+        checksum = sha256_hash.hexdigest()
+
+        # prepare the multipart/form-data request
+        form_data = aiohttp.FormData()
+        form_data.add_field('checksum', checksum)
+        form_data.add_field('keepsettings', str(keep_settings).lower())
+        form_data.add_field('update.zip', open(file, 'rb'), filename='update.zip')
+
+        await self.send_command("systemupdate", form=form_data)


### PR DESCRIPTION
Add firmware upgrade functionality for ePIC miners

- Implement `upgrade_firmware` method in `pyasic/miners/backends/epic.py`
  - Allows upgrading firmware with options to keep settings

- Enhance `system_update` method in `pyasic/web/epic.py`
  - Calculates SHA256 checksum for firmware file
  - Prepares multipart/form-data request for firmware upload
  - Sends command to update system firmware

- Update `send_command` method to handle form data and retries
  - Supports both POST and GET requests
  - Includes error handling and retries for failed attempts
  
Reference:  https://app.swaggerhub.com/apis/ePIC-Blockchain/umc_api/0.50.1#/post/update_system
