### PR TITLE
feat: Add PoolUrl dataclass 

### DIFF
--- a/pyasic/data/pools.py
+++ b/pyasic/data/pools.py
@@ -15,8 +15,8 @@ class PoolUrl:
     pubkey: Optional[str] = None
 
     def __str__(self) -> str:
-        if self.scheme == Scheme.STRATUM_V2 and self.pubKey:
-            return f"{self.scheme.value}://{self.host}:{self.port}/{self.pubKey}"
+        if self.scheme == Scheme.STRATUM_V2 and self.pubkey:
+            return f"{self.scheme.value}://{self.host}:{self.port}/{self.pubkey}"
         else:
             return f"{self.scheme.value}://{self.host}:{self.port}"
 

--- a/pyasic/data/pools.py
+++ b/pyasic/data/pools.py
@@ -1,4 +1,24 @@
 from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+
+class Scheme (Enum):
+    STRATUM_V1 = "stratum+tcp"
+    STRATUM_V2 = "stratum2+tcp"
+
+@dataclass
+class PoolUrl:
+    scheme: Scheme
+    host: str
+    port: int
+    pubKey: Optional[str] = None
+
+    def __str__(self) -> str:
+        if self.scheme == Scheme.STRATUM_V2 and self.pubKey:
+            return f"{self.scheme.value}://{self.host}:{self.port}/{self.pubKey}"
+        else:
+            return f"{self.scheme.value}://{self.host}:{self.port}"
 
 
 @dataclass
@@ -19,15 +39,15 @@ class PoolMetrics:
     pool_stale_percent: Percentage of stale shares by the pool.
     """
 
-    accepted: int = None
-    rejected: int = None
-    get_failures: int = None
-    remote_failures: int = None
-    active: bool = None
-    alive: bool = None
-    url: str = None
-    index: int = None
-    user: str = None
+    accepted: int
+    rejected: int
+    get_failures: int
+    remote_failures: int
+    active: bool
+    alive: bool
+    url: PoolUrl
+    index: int
+    user: str
     pool_rejected_percent: float = field(init=False)
     pool_stale_percent: float = field(init=False)
 

--- a/pyasic/data/pools.py
+++ b/pyasic/data/pools.py
@@ -1,11 +1,13 @@
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
+from urllib.parse import urlparse
 
 
 class Scheme (Enum):
     STRATUM_V1 = "stratum+tcp"
     STRATUM_V2 = "stratum2+tcp"
+
 
 @dataclass
 class PoolUrl:
@@ -19,6 +21,15 @@ class PoolUrl:
             return f"{self.scheme.value}://{self.host}:{self.port}/{self.pubkey}"
         else:
             return f"{self.scheme.value}://{self.host}:{self.port}"
+
+    @classmethod
+    def from_str(cls, url: str) -> 'PoolUrl':
+        parsed_url = urlparse(url)
+        scheme = Scheme(parsed_url.scheme)
+        host = parsed_url.hostname
+        port = parsed_url.port
+        pubkey = parsed_url.path.lstrip('/') if scheme == Scheme.STRATUM_V2 else None
+        return cls(scheme=scheme, host=host, port=port, pubkey=pubkey)
 
 
 @dataclass

--- a/pyasic/data/pools.py
+++ b/pyasic/data/pools.py
@@ -12,7 +12,7 @@ class PoolUrl:
     scheme: Scheme
     host: str
     port: int
-    pubKey: Optional[str] = None
+    pubkey: Optional[str] = None
 
     def __str__(self) -> str:
         if self.scheme == Scheme.STRATUM_V2 and self.pubKey:
@@ -39,17 +39,17 @@ class PoolMetrics:
     pool_stale_percent: Percentage of stale shares by the pool.
     """
 
-    accepted: int
-    rejected: int
-    get_failures: int
-    remote_failures: int
-    active: bool
-    alive: bool
-    url: PoolUrl
-    index: int
-    user: str
     pool_rejected_percent: float = field(init=False)
     pool_stale_percent: float = field(init=False)
+    url: PoolUrl
+    accepted: int = None
+    rejected: int = None
+    get_failures: int = None
+    remote_failures: int = None
+    active: bool = None
+    alive: bool = None
+    index: int = None
+    user: str = None
 
     @property
     def pool_rejected_percent(self) -> float:  # noqa - Skip PyCharm inspection


### PR DESCRIPTION

This PR adds the poolUrl dataclass to pools.py which was suggested in PR #145 @b-rowan and here are the changes made: 

-  Created a `Scheme` Enum with `STRATUM_V1` and `STRATUM_V2` variants.
-  Defined the `PoolUrl` dataclass with `scheme`, `host`, `port`, and an optional `pubkey`.
-  Updated `PoolMetrics` to include a `PoolUrl` attribute.

I plan to modify the `_get_pools` methods to parse URLs and populate `poolUrl` instances.