### PR TITLE
bug: Add custom auth to Digest of AntMiner model check

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ if __name__ == "__main__":
 ```python
 from pyasic import settings
 
-settings.update("default_antminer_password", "my_pwd")
+settings.update("default_antminer_web_password", "my_pwd")
 ```
 
 ##### Default values:

--- a/docs/index.md
+++ b/docs/index.md
@@ -249,7 +249,7 @@ if __name__ == "__main__":
 ```python
 from pyasic import settings
 
-settings.update("default_antminer_password", "my_pwd")
+settings.update("default_antminer_web_password", "my_pwd")
 ```
 
 ##### Default values:

--- a/docs/settings/settings.md
+++ b/docs/settings/settings.md
@@ -15,7 +15,8 @@ Settings options:
 - `antminer_mining_mode_as_str`
 - `default_whatsminer_password`
 - `default_innosilicon_password`
-- `default_antminer_password`
+- `default_antminer_web_password`
+- `default_antminer_ssh_password`
 - `default_bosminer_password`
 - `default_vnish_password`
 - `default_goldshell_password`

--- a/pyasic/miners/backends/braiins_os.py
+++ b/pyasic/miners/backends/braiins_os.py
@@ -189,7 +189,6 @@ class BOSMiner(BraiinsOSFirmware):
 
     async def send_config(self, config: MinerConfig, user_suffix: str = None) -> None:
         self.config = config
-        print(config)
         parsed_cfg = config.as_bosminer(user_suffix=user_suffix)
 
         toml_conf = toml.dumps(

--- a/pyasic/miners/factory.py
+++ b/pyasic/miners/factory.py
@@ -834,7 +834,7 @@ class MinerFactory:
     async def _get_model_antminer_web(self, ip: str) -> str | None:
         # last resort, this is slow
         auth = httpx.DigestAuth(
-            "root", settings.get("default_antminer_password", "root")
+            "root", settings.get("default_antminer_web_password", "root")
         )
         web_json_data = await self.send_web_command(
             ip, "/cgi-bin/get_system_info.cgi", auth=auth

--- a/pyasic/miners/factory.py
+++ b/pyasic/miners/factory.py
@@ -833,7 +833,9 @@ class MinerFactory:
 
     async def _get_model_antminer_web(self, ip: str) -> str | None:
         # last resort, this is slow
-        auth = httpx.DigestAuth("root", "root")
+        auth = httpx.DigestAuth(
+            "root", settings.get("default_antminer_password", "root")
+        )
         web_json_data = await self.send_web_command(
             ip, "/cgi-bin/get_system_info.cgi", auth=auth
         )


### PR DESCRIPTION
This fixes the fact that the DigestAuth in the MinerFactory for checking the model of AntMiner has hardcoded values. This causes the send_web_command receives incorrect auth data as it is. Minor issue as it probably never will be actually faster. 