### PR TITLE
Use builtin tomllib where possible and tomli{-w} where not.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1067,14 +1067,25 @@ files = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = ">=3.7"
 files = [
-    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
-    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.0.0"
+description = "A lil' TOML writer"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomli_w-1.0.0-py3-none-any.whl", hash = "sha256:9f2a07e8be30a0729e533ec968016807069991ae2fd921a78d42f429ae5f4463"},
+    {file = "tomli_w-1.0.0.tar.gz", hash = "sha256:f463434305e0336248cac9c2dc8076b707d8a12d019dd349f5c1e382dd1ae1b9"},
 ]
 
 [[package]]
@@ -1184,4 +1195,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "be96d28fb2d257294061aa04fa3046c5e2a7c672275f819cb253b366b52554b3"
+content-hash = "05cf32d9e1c66d2090f3506be3e5065f810c1761ce69d2bc6956db1ba8f30548"

--- a/pyasic/miners/backends/braiins_os.py
+++ b/pyasic/miners/backends/braiins_os.py
@@ -20,7 +20,11 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 import aiofiles
-import toml
+import tomli_w
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
 
 from pyasic.config import MinerConfig
 from pyasic.config.mining import MiningModePowerTune
@@ -177,10 +181,10 @@ class BOSMiner(BraiinsOSFirmware):
         raw_data = await self.ssh.get_config_file()
 
         try:
-            toml_data = toml.loads(raw_data)
+            toml_data = tomllib.loads(raw_data)
             cfg = MinerConfig.from_bosminer(toml_data)
             self.config = cfg
-        except toml.TomlDecodeError as e:
+        except tomllib.TOMLDecodeError as e:
             raise APIError("Failed to decode toml when getting config.") from e
         except TypeError as e:
             raise APIError("Failed to decode toml when getting config.") from e
@@ -191,7 +195,7 @@ class BOSMiner(BraiinsOSFirmware):
         self.config = config
         parsed_cfg = config.as_bosminer(user_suffix=user_suffix)
 
-        toml_conf = toml.dumps(
+        toml_conf = tomli_w.dumps(
             {
                 "format": {
                     "version": "2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ httpx = ">=0.26.0"
 asyncssh = ">=2.14.2"
 passlib = ">=1.7.4"
 pyaml = ">=23.12.0"
-toml = ">=0.10.2"
+tomli = { version = ">=2.0.1", python = "<3.11" }
+tomli-w = "1.0.0"
 betterproto = ">=2.0.0b6"
 aiofiles = ">=23.2.1"
 


### PR DESCRIPTION
The tomli libraries seem to be the preferred way to handle toml when the native python tomllib is not available.