### PR TITLE
Fix issue with BraiinsOS pool health check failing

### DIFF
--- a/pyasic/miners/backends/braiins_os.py
+++ b/pyasic/miners/backends/braiins_os.py
@@ -1093,7 +1093,7 @@ class BOSer(BraiinsOSFirmware):
                     get_failures=0,
                     remote_failures=0,
                     active=pool_info.get("active", False),
-                    alive=pool_info["alive"],
+                    alive=pool_info.get("alive"),
                 )
                 pools_data.append(pool_data)
 


### PR DESCRIPTION
Ran into this issue a few times when the miner was stuck in a bad state with no active pool. BraiinsOS would basically not include `alive` which then threw a `KeyError`.