### PR TITLE
add json serialization to the Scheme class

### DIFF
--- a/pyasic/data/__init__.py
+++ b/pyasic/data/__init__.py
@@ -23,7 +23,7 @@ from typing import Any, List, Union
 
 from pyasic.config import MinerConfig
 from pyasic.config.mining import MiningModePowerTune
-from pyasic.data.pools import PoolMetrics
+from pyasic.data.pools import PoolMetrics, Scheme
 
 from .boards import HashBoard
 from .device import DeviceInfo
@@ -154,7 +154,11 @@ class MinerData:
 
     @staticmethod
     def dict_factory(x):
-        return {k: v for (k, v) in x if not k.startswith("_")}
+        return {
+            k: v.value if isinstance(v, Scheme) else v
+            for (k, v) in x
+            if not k.startswith("_")
+        }
 
     def __post_init__(self):
         self._datetime = datetime.now(timezone.utc).astimezone()

--- a/pyasic/data/pools.py
+++ b/pyasic/data/pools.py
@@ -8,6 +8,9 @@ class Scheme(Enum):
     STRATUM_V1 = "stratum+tcp"
     STRATUM_V2 = "stratum2+tcp"
     STRATUM_V1_SSL = "stratum+ssl"
+    
+    def __json__(self):
+        return self.value
 
 
 @dataclass

--- a/pyasic/data/pools.py
+++ b/pyasic/data/pools.py
@@ -8,9 +8,6 @@ class Scheme(Enum):
     STRATUM_V1 = "stratum+tcp"
     STRATUM_V2 = "stratum2+tcp"
     STRATUM_V1_SSL = "stratum+ssl"
-    
-    def __json__(self):
-        return self.value
 
 
 @dataclass


### PR DESCRIPTION
When calling `as_json()`on `MinerData`containing a Scheme attribute (like BOS+ miners), the Scheme enum can't get serialized, resulting in this error:

`TypeError: Object of type Scheme is not JSON serializable`

Adding

`def __json__(self):
        return self.value`

To the Scheme class will allow it to be converted to JSON.