### PR TITLE
feature: set power limit for vnish

### DIFF
--- a/pyasic/miners/backends/vnish.py
+++ b/pyasic/miners/backends/vnish.py
@@ -14,6 +14,7 @@
 #  limitations under the License.                                              -
 # ------------------------------------------------------------------------------
 
+import logging
 from typing import Optional
 
 from pyasic import MinerConfig
@@ -272,3 +273,19 @@ class VNish(VNishFirmware, BMMiner):
             return self.config
         self.config = MinerConfig.from_vnish(web_settings, web_presets)
         return self.config
+
+    async def set_power_limit(self, wattage: int) -> bool:
+        # Can only set power limit to tuned preset
+        try:
+            await self.web.set_power_limit(wattage)
+            updated_settings = await self.web.settings()
+        except APIError:
+            raise
+        except Exception as e:
+            logging.warning(f"{self} - Failed to set power limit: {e}")
+            return False
+
+        if int(updated_settings["miner"]["overclock"]["preset"]) == wattage:
+            return True
+        else:
+            return False

--- a/pyasic/miners/backends/vnish.py
+++ b/pyasic/miners/backends/vnish.py
@@ -275,7 +275,16 @@ class VNish(VNishFirmware, BMMiner):
         return self.config
 
     async def set_power_limit(self, wattage: int) -> bool:
+        config = await self.get_config()
+        tuned_presets = [
+            preset.power
+            for preset in config.mining_mode.available_presets
+            if preset.tuned
+        ]
+
         # Can only set power limit to tuned preset
+        if wattage not in tuned_presets:
+            return False
         try:
             await self.web.set_power_limit(wattage)
             updated_settings = await self.web.settings()

--- a/pyasic/miners/backends/vnish.py
+++ b/pyasic/miners/backends/vnish.py
@@ -97,6 +97,7 @@ class VNish(VNishFirmware, BMMiner):
 
     supports_shutdown = True
     supports_presets = True
+    supports_autotuning = True
 
     data_locations = VNISH_DATA_LOC
 

--- a/pyasic/web/vnish.py
+++ b/pyasic/web/vnish.py
@@ -138,6 +138,15 @@ class VNishWebAPI(BaseWebAPI):
     async def settings(self) -> dict:
         return await self.send_command("settings")
 
+    async def set_power_limit(self, wattage: int) -> bool:
+        # Can only set power limit to tuned preset
+        settings = await self.settings()
+        settings["miner"]["overclock"]["preset"] = str(wattage)
+        new_settings = {"miner": {"overclock": settings["miner"]["overclock"]}}
+
+        # response will always be {"restart_required":false,"reboot_required":false} even if unsuccessful
+        return await self.send_command("settings", privileged=True, **new_settings)
+
     async def autotune_presets(self) -> dict:
         return await self.send_command("autotune/presets")
 


### PR DESCRIPTION
I want to be able to change power for vnish miner using the power slider in [hass-miner](https://github.com/Schnitzel/hass-miner). To do that, `set_power_limit` needs to be implemented in pyasic.

Notes
- Setting power with vnish only works with tuned values. If you call the method with an untuned value, the power doesn't change. It will return the same response (i.e., `{"restart_required":false,"reboot_required":false}`)
- The backend confirms that the power change is successful by getting the updated settings and checking that `updated_settings["miner"]["overclock"]["preset"]` has the desired wattage.
- In the backend, I tried to handle error-handling similarly to how it's done in [BOSMiner](https://github.com/UpstreamData/pyasic/blob/master/pyasic/miners/backends/braiins_os.py#L229) and [BOSer](https://github.com/UpstreamData/pyasic/blob/master/pyasic/miners/backends/braiins_os.py#L817). Should this be handled differently?