### PR TITLE
feature: add support for mining presets

### DIFF
--- a/pyasic/config/__init__.py
+++ b/pyasic/config/__init__.py
@@ -245,13 +245,13 @@ class MinerConfig(BaseModel):
         )
 
     @classmethod
-    def from_vnish(cls, web_settings: dict) -> "MinerConfig":
+    def from_vnish(cls, web_settings: dict, web_presets: list[dict]) -> "MinerConfig":
         """Constructs a MinerConfig object from web settings for VNish miners."""
         return cls(
             pools=PoolConfig.from_vnish(web_settings),
             fan_mode=FanModeConfig.from_vnish(web_settings),
             temperature=TemperatureConfig.from_vnish(web_settings),
-            mining_mode=MiningModeConfig.from_vnish(web_settings),
+            mining_mode=MiningModeConfig.from_vnish(web_settings, web_presets),
         )
 
     @classmethod

--- a/pyasic/config/mining/__init__.py
+++ b/pyasic/config/mining/__init__.py
@@ -36,6 +36,7 @@ from pyasic.web.braiins_os.proto.braiins.bos.v1 import (
 )
 
 from .algo import TunerAlgo, TunerAlgoType
+from .presets import MiningPreset
 from .scaling import ScalingConfig
 
 
@@ -344,6 +345,14 @@ class MiningModeHashrateTune(MinerConfigValue):
         return {"autotunerset": {"enabled": True}}
 
 
+class MiningModePreset(MinerConfigValue):
+    active_preset: MiningPreset
+    available_presets: list[MiningPreset] = field(default_factory=list)
+
+    def as_vnish(self) -> dict:
+        return {"overclock": {**self.active_preset.as_vnish()}}
+
+
 class ManualBoardSettings(MinerConfigValue):
     freq: float
     volt: float
@@ -444,6 +453,7 @@ class MiningModeConfig(MinerConfigOption):
     sleep = MiningModeSleep
     power_tuning = MiningModePowerTune
     hashrate_tuning = MiningModeHashrateTune
+    preset = MiningModePreset
     manual = MiningModeManual
 
     @classmethod
@@ -673,5 +683,6 @@ MiningMode = TypeVar(
         MiningModeManual,
         MiningModePowerTune,
         MiningModeHashrateTune,
+        MiningModePreset,
     ],
 )

--- a/pyasic/config/mining/presets.py
+++ b/pyasic/config/mining/presets.py
@@ -1,0 +1,14 @@
+from pyasic.config.base import MinerConfigValue
+
+
+class MiningPreset(MinerConfigValue):
+    name: str | None = None
+    power: int | None = None
+    hashrate: int | None = None
+    tuned: bool | None = None
+    modded_psu: bool = False
+
+    def as_vnish(self) -> dict:
+        if self.name is not None:
+            return {"preset": self.name}
+        return {}

--- a/pyasic/config/mining/presets.py
+++ b/pyasic/config/mining/presets.py
@@ -12,3 +12,23 @@ class MiningPreset(MinerConfigValue):
         if self.name is not None:
             return {"preset": self.name}
         return {}
+
+    @classmethod
+    def from_vnish(cls, web_preset: dict):
+        name = web_preset["name"]
+        hr_power_split = web_preset["pretty"].split("~")
+        if len(hr_power_split) == 1:
+            power = None
+            hashrate = None
+        else:
+            power = hr_power_split[0].replace("watt", "").strip()
+            hashrate = hr_power_split[1].replace("TH", "").strip()
+        tuned = web_preset["status"] == "tuned"
+        modded_psu = web_preset["modded_psu_required"]
+        return cls(
+            name=name,
+            power=power,
+            hashrate=hashrate,
+            tuned=tuned,
+            modded_psu=modded_psu,
+        )

--- a/pyasic/miners/backends/vnish.py
+++ b/pyasic/miners/backends/vnish.py
@@ -266,7 +266,8 @@ class VNish(VNishFirmware, BMMiner):
     async def get_config(self) -> MinerConfig:
         try:
             web_settings = await self.web.settings()
+            web_presets = await self.web.autotune_presets()
         except APIError:
             return self.config
-        self.config = MinerConfig.from_vnish(web_settings)
+        self.config = MinerConfig.from_vnish(web_settings, web_presets)
         return self.config

--- a/pyasic/miners/backends/vnish.py
+++ b/pyasic/miners/backends/vnish.py
@@ -95,6 +95,7 @@ class VNish(VNishFirmware, BMMiner):
     web: VNishWebAPI
 
     supports_shutdown = True
+    supports_presets = True
 
     data_locations = VNISH_DATA_LOC
 

--- a/pyasic/miners/base.py
+++ b/pyasic/miners/base.py
@@ -56,6 +56,7 @@ class MinerProtocol(Protocol):
 
     supports_shutdown: bool = False
     supports_power_modes: bool = False
+    supports_presets: bool = False
     supports_autotuning: bool = False
 
     api_ver: str = None


### PR DESCRIPTION
Adds support for mining mode presets (used by vnish and luxos mainly), as well as a flag, `supports_presets` to check against.  Presets will be included in the config, including available presets, so that they can be selected from and sent to the miner.

Hopefully a partial prefix to #245.