### PR TITLE
Fix BOSer rpc

### DIFF
--- a/pyasic/miners/backends/braiins_os.py
+++ b/pyasic/miners/backends/braiins_os.py
@@ -746,7 +746,7 @@ class BOSer(BraiinsOSFirmware):
     """Handler for new versions of BraiinsOS+ (post-gRPC)"""
 
     _rpc_cls = BOSMinerRPCAPI
-    web: BOSMinerRPCAPI
+    rpc: BOSMinerRPCAPI
     _web_cls = BOSerWebAPI
     web: BOSerWebAPI
 


### PR DESCRIPTION
In `BOSer`, it looks like there was a copy/paste error where `rpc` attribute was missing and  `web` was duplicated