### PR TITLE
fix: change sticker hashrate to GH for Hammer and VolcMiner

### DIFF
--- a/pyasic/miners/backends/hammer.py
+++ b/pyasic/miners/backends/hammer.py
@@ -173,8 +173,8 @@ class BlackMiner(StockFirmware):
         if rpc_summary is not None:
             try:
                 return self.algo.hashrate(
-                    rate=float(rpc_summary["SUMMARY"][0]["GHS 5s"]),
-                    unit=self.algo.unit.GH,
+                    rate=float(rpc_summary["SUMMARY"][0]["MHS 5s"]),
+                    unit=self.algo.unit.MH,
                 ).into(self.algo.unit.default)
             except (LookupError, ValueError, TypeError):
                 pass
@@ -229,7 +229,7 @@ class BlackMiner(StockFirmware):
                         hashrate = boards[1].get(f"chain_rate{i}")
                         if hashrate:
                             hashboard.hashrate = self.algo.hashrate(
-                                rate=float(hashrate), unit=self.algo.unit.GH
+                                rate=float(hashrate), unit=self.algo.unit.MH
                             ).into(self.algo.unit.default)
 
                         chips = boards[1].get(f"chain_acn{i}")
@@ -358,7 +358,7 @@ class BlackMiner(StockFirmware):
             try:
                 expected_rate = rpc_stats["STATS"][1].get("total_rateideal")
                 if expected_rate is None:
-                    expected_rate = self.sticker_hashrate
+                    return self.sticker_hashrate
                 try:
                     rate_unit = rpc_stats["STATS"][1]["rate_unit"]
                 except KeyError:

--- a/pyasic/miners/hammer/blackminer/DX/D10.py
+++ b/pyasic/miners/hammer/blackminer/DX/D10.py
@@ -1,7 +1,7 @@
+from pyasic.device.algorithm.hashrate.unit.scrypt import ScryptUnit
+from pyasic.device.algorithm.scrypt import ScryptHashRate
 from pyasic.miners.backends import BlackMiner
 from pyasic.miners.device.models import D10
-from pyasic.device.algorithm.scrypt import ScryptHashRate
-from pyasic.device.algorithm.hashrate.unit.scrypt import ScryptUnit
 
 
 class HammerD10(BlackMiner, D10):

--- a/pyasic/miners/hammer/blackminer/DX/D10.py
+++ b/pyasic/miners/hammer/blackminer/DX/D10.py
@@ -3,4 +3,4 @@ from pyasic.miners.device.models import D10
 
 
 class HammerD10(BlackMiner, D10):
-    sticker_hashrate = 5000
+    sticker_hashrate = 5000000

--- a/pyasic/miners/hammer/blackminer/DX/D10.py
+++ b/pyasic/miners/hammer/blackminer/DX/D10.py
@@ -1,6 +1,8 @@
 from pyasic.miners.backends import BlackMiner
 from pyasic.miners.device.models import D10
+from pyasic.device.algorithm.scrypt import ScryptHashRate
+from pyasic.device.algorithm.hashrate.unit.scrypt import ScryptUnit
 
 
 class HammerD10(BlackMiner, D10):
-    sticker_hashrate = 5000000
+    sticker_hashrate = ScryptHashRate(rate=5.0, unit=ScryptUnit.GH)

--- a/pyasic/miners/volcminer/blackminer/DX/D1.py
+++ b/pyasic/miners/volcminer/blackminer/DX/D1.py
@@ -1,6 +1,8 @@
 from pyasic.miners.backends import BlackMiner
 from pyasic.miners.device.models import D1
+from pyasic.device.algorithm.scrypt import ScryptHashRate
+from pyasic.device.algorithm.hashrate.unit.scrypt import ScryptUnit
 
 
 class VolcMinerD1(BlackMiner, D1):
-    sticker_hashrate = 15150000
+    sticker_hashrate = ScryptHashRate(rate=15.15, unit=ScryptUnit.GH)

--- a/pyasic/miners/volcminer/blackminer/DX/D1.py
+++ b/pyasic/miners/volcminer/blackminer/DX/D1.py
@@ -3,4 +3,4 @@ from pyasic.miners.device.models import D1
 
 
 class VolcMinerD1(BlackMiner, D1):
-    sticker_hashrate = 15150
+    sticker_hashrate = 15150000

--- a/pyasic/miners/volcminer/blackminer/DX/D1.py
+++ b/pyasic/miners/volcminer/blackminer/DX/D1.py
@@ -1,7 +1,7 @@
+from pyasic.device.algorithm.hashrate.unit.scrypt import ScryptUnit
+from pyasic.device.algorithm.scrypt import ScryptHashRate
 from pyasic.miners.backends import BlackMiner
 from pyasic.miners.device.models import D1
-from pyasic.device.algorithm.scrypt import ScryptHashRate
-from pyasic.device.algorithm.hashrate.unit.scrypt import ScryptUnit
 
 
 class VolcMinerD1(BlackMiner, D1):


### PR DESCRIPTION
Keep the hashrates consistent across the API and the sticker_hashrate