### PR TITLE
fix hammer test, enforce default hr unit

### DIFF
--- a/pyasic/miners/backends/hammer.py
+++ b/pyasic/miners/backends/hammer.py
@@ -229,7 +229,7 @@ class BlackMiner(StockFirmware):
                         hashrate = boards[1].get(f"chain_rate{i}")
                         if hashrate:
                             hashboard.hashrate = self.algo.hashrate(
-                                rate=float(hashrate), unit=self.algo.unit.GH
+                                rate=float(hashrate), unit=self.algo.unit.MH
                             ).into(self.algo.unit.default)
 
                         chips = boards[1].get(f"chain_acn{i}")
@@ -358,7 +358,7 @@ class BlackMiner(StockFirmware):
             try:
                 expected_rate = rpc_stats["STATS"][1].get("total_rateideal")
                 if expected_rate is None:
-                    return self.sticker_hashrate
+                    return self.sticker_hashrate.into(self.algo.unit.default)
                 try:
                     rate_unit = rpc_stats["STATS"][1]["rate_unit"]
                 except KeyError:

--- a/tests/miners_tests/backends_tests/hammer_tests/version_2023_05_28.py
+++ b/tests/miners_tests/backends_tests/hammer_tests/version_2023_05_28.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from pyasic import APIError, MinerData
 from pyasic.data import Fan, HashBoard
+from pyasic.device.algorithm.hashrate.unit.scrypt import ScryptUnit
 from pyasic.miners.hammer import HammerD10
 
 POOLS = [
@@ -398,6 +399,6 @@ class TestHammerMiners(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(result.api_ver, "3.1")
             self.assertEqual(result.fw_ver, "2023-05-28 17-20-35 CST")
             self.assertEqual(result.hostname, "Hammer")
-            self.assertEqual(round(result.hashrate), 4686)
+            self.assertEqual(round(result.hashrate.into(ScryptUnit.MH)), 4686)
             self.assertEqual(result.fans, [Fan(speed=4650), Fan(speed=4500)])
             self.assertEqual(result.total_chips, result.expected_chips)


### PR DESCRIPTION
Fix Hammer test. Test was failing due to HR being returned as GH, which when rounded lost precision 