### PR TITLE
feature: add support for Vnish S19j Pro A

### DIFF
--- a/pyasic/miners/factory.py
+++ b/pyasic/miners/factory.py
@@ -557,6 +557,7 @@ MINER_CLASSES = {
         "ANTMINER S19 PRO": VNishS19Pro,
         "ANTMINER S19J": VNishS19j,
         "ANTMINER S19J PRO": VNishS19jPro,
+        "ANTMINER S19J PRO A": VNishS19jPro,
         "ANTMINER S19J PRO BB": VNishS19jPro,
         "ANTMINER S19A": VNishS19a,
         "ANTMINER S19A PRO": VNishS19aPro,


### PR DESCRIPTION
Fixes  #270

> Just need to combine them in miners.antminer.vnish.x19, make sure they're imported in that init (it's all star inputs all the way up from there), then add the model string in all caps to the MINER_CLASSES dict in factory.

I realized that I only needed to update MINER_CLASSES dict in factory and didn't need to add anything to `miners.antminer.vnish.x19` since is the miner is a `VNishS19jPro`

I saw that  [`ANTMINER S19J PRO BB`](https://github.com/UpstreamData/pyasic/commit/c19945bb82dd99b64cefcddfa1329520d4ff47df) had been added similarly in the past

I confirmed that this works by re-running my previous code (`await get_miner("192.168.1.184")`), and the warning no longer appears.