### PR TITLE
docs: fix issues for docs warnings

### DIFF
--- a/pyasic/miners/backends/luxminer.py
+++ b/pyasic/miners/backends/luxminer.py
@@ -151,7 +151,7 @@ class LUXMiner(LuxOSFirmware):
             bool: True if the firmware upgrade was successfully initiated, False otherwise.
         """
         try:
-            await self.rpc.upgraderun()
+            await self.rpc.updaterun()
             logging.info(f"{self.ip}: Firmware upgrade initiated successfully.")
             return True
 

--- a/pyasic/rpc/luxminer.py
+++ b/pyasic/rpc/luxminer.py
@@ -574,9 +574,6 @@ class LUXMinerRPCAPI(BaseMinerRPCAPI):
         <details>
             <summary>Expand</summary>
 
-        Parameters:
-            session_id: Session id from the logon command.
-
         Returns:
             Confirmation of logging off a session.
         </details>
@@ -844,7 +841,7 @@ class LUXMinerRPCAPI(BaseMinerRPCAPI):
         """
         return await self.send_privileged_command("voltageset", board_n, voltage)
 
-    async def upgraderun(self):
+    async def updaterun(self) -> dict:
         """
         Send the 'updaterun' command to the miner.
 

--- a/pyasic/web/auradine.py
+++ b/pyasic/web/auradine.py
@@ -268,11 +268,11 @@ class AuradineWebAPI(BaseWebAPI):
         """
         return await self.send_command("mode")
 
-    async def set_mode(self, **kwargs) -> dict:
+    async def set_mode(self, **kwargs: Any) -> dict:
         """Set the operational mode of the Auradine miner.
 
         Args:
-            **kwargs: Mode settings specified as keyword arguments.
+            **kwargs (Any): Mode settings specified as keyword arguments.
 
         Returns:
             dict: A dictionary indicating the result of the mode setting operation.
@@ -287,11 +287,11 @@ class AuradineWebAPI(BaseWebAPI):
         """
         return await self.send_command("network")
 
-    async def set_network(self, **kwargs) -> dict:
+    async def set_network(self, **kwargs: Any) -> dict:
         """Set the network configuration of the Auradine miner.
 
         Args:
-            **kwargs: Network settings specified as keyword arguments.
+            **kwargs (Any): Network settings specified as keyword arguments.
 
         Returns:
             dict: A dictionary indicating the result of the network configuration.


### PR DESCRIPTION
When I build the docs locally (`poetry run mkdocs serve`), there are a couple warnings. This PR fixes those issues.

```
INFO    -  Building documentation...
INFO    -  Cleaning site directory
WARNING -  griffe: pyasic/rpc/luxminer.py:578: No type or
           annotation for parameter 'session_id'
WARNING -  griffe: pyasic/rpc/luxminer.py:578: Parameter
           'session_id' does not appear in the function
           signature
WARNING -  griffe: pyasic/rpc/luxminer.py:851: No type or
           annotation for returned value 1
WARNING -  griffe: pyasic/web/auradine.py:275: No type or
           annotation for parameter '**kwargs'
WARNING -  griffe: pyasic/web/auradine.py:294: No type or
           annotation for parameter '**kwargs'
INFO    -  Documentation built in 12.09 seconds
INFO    -  [04:44:25] Watching paths for changes: 'docs',
           'mkdocs.yml'
INFO    -  [04:44:25] Serving on http://127.0.0.1:8000/
```