### PR TITLE
feature: add _get_wattage_limit for luxos

### DIFF
--- a/pyasic/config/mining/__init__.py
+++ b/pyasic/config/mining/__init__.py
@@ -371,17 +371,24 @@ class MiningModePreset(MinerConfigValue):
     def from_luxos(
         cls, rpc_config: dict, rpc_profiles: list[dict]
     ) -> "MiningModePreset":
-        active_preset = None
-        active_profile = rpc_config["CONFIG"][0]["Profile"]
-        for profile in rpc_profiles["PROFILES"]:
-            if profile["Profile Name"] == active_profile:
-                active_preset = profile
+        active_preset = cls.get_active_preset_from_luxos(rpc_config, rpc_profiles)
         return cls(
             active_preset=MiningPreset.from_luxos(active_preset),
             available_presets=[
                 MiningPreset.from_luxos(p) for p in rpc_profiles["PROFILES"]
             ],
         )
+
+    @classmethod
+    def get_active_preset_from_luxos(
+        cls, rpc_config: dict, rpc_profiles: list[dict]
+    ) -> dict:
+        active_preset = None
+        active_profile = rpc_config["CONFIG"][0]["Profile"]
+        for profile in rpc_profiles["PROFILES"]:
+            if profile["Profile Name"] == active_profile:
+                active_preset = profile
+        return active_preset
 
 
 class ManualBoardSettings(MinerConfigValue):
@@ -705,7 +712,11 @@ class MiningModeConfig(MinerConfigOption):
 
     @classmethod
     def from_luxos(cls, rpc_config: dict, rpc_profiles: dict):
-        return MiningModePreset.from_luxos(rpc_config, rpc_profiles)
+        preset_info = MiningModePreset.from_luxos(rpc_config, rpc_profiles)
+        return cls.preset(
+            active_preset=preset_info.active_preset,
+            available_presets=preset_info.available_presets,
+        )
 
 
 MiningMode = TypeVar(

--- a/pyasic/miners/backends/luxminer.py
+++ b/pyasic/miners/backends/luxminer.py
@@ -47,6 +47,10 @@ LUXMINER_DATA_LOC = DataLocations(
             "_get_wattage",
             [RPCAPICommand("rpc_power", "power")],
         ),
+        str(DataOptions.WATTAGE_LIMIT): DataFunction(
+            "_get_wattage_limit",
+            [],
+        ),
         str(DataOptions.FANS): DataFunction(
             "_get_fans",
             [RPCAPICommand("rpc_fans", "fans")],
@@ -286,6 +290,15 @@ class LUXMiner(LuxOSFirmware):
         if rpc_power is not None:
             try:
                 return rpc_power["POWER"][0]["Watts"]
+            except (LookupError, ValueError, TypeError):
+                pass
+
+    async def _get_wattage_limit(self) -> Optional[int]:
+        config = await self.get_config()
+
+        if config is not None:
+            try:
+                return int(config.mining_mode.active_preset.power)
             except (LookupError, ValueError, TypeError):
                 pass
 

--- a/pyasic/miners/backends/luxminer.py
+++ b/pyasic/miners/backends/luxminer.py
@@ -17,6 +17,7 @@ import logging
 from typing import List, Optional
 
 from pyasic.config import MinerConfig
+from pyasic.config.mining_mode import MiningModePreset
 from pyasic.data import Fan, HashBoard
 from pyasic.data.pools import PoolMetrics, PoolUrl
 from pyasic.device.algorithm import AlgoHashRate
@@ -24,7 +25,6 @@ from pyasic.errors import APIError
 from pyasic.miners.data import DataFunction, DataLocations, DataOptions, RPCAPICommand
 from pyasic.miners.device.firmware import LuxOSFirmware
 from pyasic.rpc.luxminer import LUXMinerRPCAPI
-from pyasic.config.mining_mode import MiningModePreset
 
 LUXMINER_DATA_LOC = DataLocations(
     **{


### PR DESCRIPTION
This PR adds `_get_wattage_limit` method for Luxos by getting the wattage from the active profile (added in #262)

This method is needed to add the ability to set the power limit in [hass-miner](https://github.com/Schnitzel/hass-miner) for Luxos miners.