### PR TITLE
Add cryptography direct dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1760,4 +1760,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.9, <4.0"
-content-hash = "6f5bcdfff0891ee60759be4a2ccb175049706e174b041fd2b33b1e85afd1edba"
+content-hash = "67a8e0d34c0d1af0f8e4d617d80fd5afc8d197e5d5444f78fd82e4f716a52965"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ requires-python = ">3.9, <4.0"
 dependencies = [
     "httpx>=0.26.0",
     "asyncssh>=2.17.0",
+    "cryptography>=39.0",
     "passlib>=1.7.4",
     "pyaml>=23.12.0",
     "tomli (>=2.2.1,<3.0.0) ; python_version < '3.11'",


### PR DESCRIPTION
Used directly [here](https://github.com/UpstreamData/pyasic/blob/v0.70.5/pyasic/rpc/btminer.py#L29).