### PR TITLE
Don't timeout forever on _socket_ping

### DIFF
--- a/pyasic/miners/factory.py
+++ b/pyasic/miners/factory.py
@@ -888,6 +888,7 @@ class MinerFactory:
             await writer.drain()
 
             # loop to receive all the data
+            timeouts_remaining = 5
             while True:
                 try:
                     d = await asyncio.wait_for(reader.read(4096), timeout=1)
@@ -895,7 +896,9 @@ class MinerFactory:
                         break
                     data += d
                 except asyncio.TimeoutError:
-                    pass
+                    timeouts_remaining -= 1
+                    if not timeouts_remaining:
+                        break
                 except ConnectionResetError:
                     return
         except asyncio.CancelledError:

--- a/pyasic/miners/factory.py
+++ b/pyasic/miners/factory.py
@@ -888,7 +888,7 @@ class MinerFactory:
             await writer.drain()
 
             # loop to receive all the data
-            timeouts_remaining = 5
+            timeouts_remaining = max(1, int(settings.get("factory_get_timeout", 3)))
             while True:
                 try:
                     d = await asyncio.wait_for(reader.read(4096), timeout=1)

--- a/pyasic/miners/factory.py
+++ b/pyasic/miners/factory.py
@@ -898,6 +898,7 @@ class MinerFactory:
                 except asyncio.TimeoutError:
                     timeouts_remaining -= 1
                     if not timeouts_remaining:
+                        logger.warning(f"{ip}: Socket ping timeout.")
                         break
                 except ConnectionResetError:
                     return


### PR DESCRIPTION
A device was crashing constantly and I couldn't figure out why. It turns out that `_socket_ping` was hanging indefinitely as  `asyncio.wait_for` was raising `asyncio.TimeoutError` indefinitely, causing the connection to never get released and since I was running `get_miner` every hour it would eventually run out of sockets.

This patch adds a max number of timeouts before we exit out. 