### PR TITLE
feat: set supports_autotuning to True for luxminer

### DIFF
--- a/pyasic/miners/backends/luxminer.py
+++ b/pyasic/miners/backends/luxminer.py
@@ -86,6 +86,7 @@ class LUXMiner(LuxOSFirmware):
 
     supports_shutdown = True
     supports_presets = True
+    supports_autotuning = True
 
     data_locations = LUXMINER_DATA_LOC
 


### PR DESCRIPTION
Previous PRs added functionality for Luxos to enable set_power_limit slider in [hass-miner](https://github.com/Schnitzel/hass-miner) (works for Braiins but not Luxos).
- [mining presets](https://github.com/UpstreamData/pyasic/pull/262)
- [`set_power_limit`](https://github.com/UpstreamData/pyasic/pull/267)
- [`get_wattage_limit`](https://github.com/UpstreamData/pyasic/pull/277)

hass-miner checks if [ `supports_autotuning` is True](https://github.com/Schnitzel/hass-miner/blob/2315cc21e0fcd00f75d42c1ddfcfb21c9e4d5d4b/custom_components/miner/number.py#L57) to set the power limit. This value is set to True for Braiins and Vnish. This PR sets it to True for Luxos

