### PR TITLE
fix: pass atmset param as bool in Luxos

### DIFF
--- a/pyasic/miners/backends/luxminer.py
+++ b/pyasic/miners/backends/luxminer.py
@@ -192,10 +192,10 @@ class LUXMiner(LuxOSFirmware):
         try:
             if await self.atm_enabled():
                 re_enable_atm = True
-                await self.rpc.atmset("enabled=false")
+                await self.rpc.atmset(enabled=False)
             result = await self.rpc.profileset(new_preset)
             if re_enable_atm:
-                await self.rpc.atmset("enabled=true")
+                await self.rpc.atmset(enabled=True)
         except APIError:
             raise
         except Exception as e:


### PR DESCRIPTION
[Previous PR](https://github.com/UpstreamData/pyasic/pull/267) added `set_power_limit` for Luxos by adding `atmset` to rpc.

This PR fixes bug in `set_power_limit` by passing `enabled` param as bool (instead of str)