### PR TITLE
feature: Add Support for Avalon Nano 3s

### DIFF
--- a/docs/miners/avalonminer/nano.md
+++ b/docs/miners/avalonminer/nano.md
@@ -14,3 +14,16 @@
         show_root_heading: false
         heading_level: 0
 
+## Avalon Nano 3s (Stock)
+
+- [ ] Shutdowns
+- [ ] Power Modes
+- [ ] Setpoints
+- [ ] Presets
+
+::: pyasic.miners.avalonminer.cgminer.nano.nano3.CGMinerAvalonNano3s
+    handler: python
+    options:
+        show_root_heading: false
+        heading_level: 0
+

--- a/docs/miners/supported_types.md
+++ b/docs/miners/supported_types.md
@@ -554,6 +554,9 @@ details {
                 <ul>
                     <li><a href="../avalonminer/nano#avalon-nano-3-stock">Avalon Nano 3 (Stock)</a></li>
                 </ul>
+                <ul>
+                    <li><a href="../avalonminer/nano#avalon-nano-3s-stock">Avalon Nano 3s (Stock)</a></li>
+                </ul>
         </details>
         <details>
             <summary>A15X Series:</summary>

--- a/pyasic/device/models.py
+++ b/pyasic/device/models.py
@@ -451,6 +451,7 @@ class AvalonminerModels(MinerModelType):
     Avalon1246 = "Avalon 1246"
     Avalon1566 = "Avalon 1566"
     AvalonNano3 = "Avalon Nano 3"
+    AvalonNano3s = "Avalon Nano 3s"
 
     def __str__(self):
         return self.value

--- a/pyasic/miners/avalonminer/cgminer/nano/__init__.py
+++ b/pyasic/miners/avalonminer/cgminer/nano/__init__.py
@@ -14,4 +14,7 @@
 #  limitations under the License.                                              -
 # ------------------------------------------------------------------------------
 
-from .nano3 import CGMinerAvalonNano3
+from .nano3 import (
+    CGMinerAvalonNano3,
+    CGMinerAvalonNano3s
+)

--- a/pyasic/miners/avalonminer/cgminer/nano/__init__.py
+++ b/pyasic/miners/avalonminer/cgminer/nano/__init__.py
@@ -14,7 +14,4 @@
 #  limitations under the License.                                              -
 # ------------------------------------------------------------------------------
 
-from .nano3 import (
-    CGMinerAvalonNano3,
-    CGMinerAvalonNano3s
-)
+from .nano3 import CGMinerAvalonNano3, CGMinerAvalonNano3s

--- a/pyasic/miners/avalonminer/cgminer/nano/nano3.py
+++ b/pyasic/miners/avalonminer/cgminer/nano/nano3.py
@@ -24,7 +24,10 @@ from pyasic.miners.data import (
     RPCAPICommand,
     WebAPICommand,
 )
-from pyasic.miners.device.models import AvalonNano3
+from pyasic.miners.device.models import (
+    AvalonNano3,
+    AvalonNano3s
+)
 from pyasic.web.avalonminer import AvalonMinerWebAPI
 
 AVALON_NANO_DATA_LOC = DataLocations(
@@ -86,6 +89,27 @@ AVALON_NANO_DATA_LOC = DataLocations(
 
 
 class CGMinerAvalonNano3(AvalonMiner, AvalonNano3):
+    _web_cls = AvalonMinerWebAPI
+    web: AvalonMinerWebAPI
+
+    data_locations = AVALON_NANO_DATA_LOC
+
+    async def _get_mac(self, web_minerinfo: dict) -> Optional[dict]:
+        if web_minerinfo is None:
+            try:
+                web_minerinfo = await self.web.minerinfo()
+            except APIError:
+                pass
+
+        if web_minerinfo is not None:
+            try:
+                mac = web_minerinfo.get("mac")
+                if mac is not None:
+                    return mac.upper()
+            except (KeyError, ValueError):
+                pass
+
+class CGMinerAvalonNano3s(AvalonMiner, AvalonNano3s):
     _web_cls = AvalonMinerWebAPI
     web: AvalonMinerWebAPI
 

--- a/pyasic/miners/avalonminer/cgminer/nano/nano3.py
+++ b/pyasic/miners/avalonminer/cgminer/nano/nano3.py
@@ -24,10 +24,7 @@ from pyasic.miners.data import (
     RPCAPICommand,
     WebAPICommand,
 )
-from pyasic.miners.device.models import (
-    AvalonNano3,
-    AvalonNano3s
-)
+from pyasic.miners.device.models import AvalonNano3, AvalonNano3s
 from pyasic.web.avalonminer import AvalonMinerWebAPI
 
 AVALON_NANO_DATA_LOC = DataLocations(
@@ -108,6 +105,7 @@ class CGMinerAvalonNano3(AvalonMiner, AvalonNano3):
                     return mac.upper()
             except (KeyError, ValueError):
                 pass
+
 
 class CGMinerAvalonNano3s(AvalonMiner, AvalonNano3s):
     pass

--- a/pyasic/miners/avalonminer/cgminer/nano/nano3.py
+++ b/pyasic/miners/avalonminer/cgminer/nano/nano3.py
@@ -110,22 +110,4 @@ class CGMinerAvalonNano3(AvalonMiner, AvalonNano3):
                 pass
 
 class CGMinerAvalonNano3s(AvalonMiner, AvalonNano3s):
-    _web_cls = AvalonMinerWebAPI
-    web: AvalonMinerWebAPI
-
-    data_locations = AVALON_NANO_DATA_LOC
-
-    async def _get_mac(self, web_minerinfo: dict) -> Optional[dict]:
-        if web_minerinfo is None:
-            try:
-                web_minerinfo = await self.web.minerinfo()
-            except APIError:
-                pass
-
-        if web_minerinfo is not None:
-            try:
-                mac = web_minerinfo.get("mac")
-                if mac is not None:
-                    return mac.upper()
-            except (KeyError, ValueError):
-                pass
+    pass

--- a/pyasic/miners/device/models/avalonminer/nano/__init__.py
+++ b/pyasic/miners/device/models/avalonminer/nano/__init__.py
@@ -1,1 +1,4 @@
-from .nano3 import AvalonNano3
+from .nano3 import (
+    AvalonNano3,
+    AvalonNano3s
+)

--- a/pyasic/miners/device/models/avalonminer/nano/__init__.py
+++ b/pyasic/miners/device/models/avalonminer/nano/__init__.py
@@ -1,4 +1,1 @@
-from .nano3 import (
-    AvalonNano3,
-    AvalonNano3s
-)
+from .nano3 import AvalonNano3, AvalonNano3s

--- a/pyasic/miners/device/models/avalonminer/nano/nano3.py
+++ b/pyasic/miners/device/models/avalonminer/nano/nano3.py
@@ -10,3 +10,11 @@ class AvalonNano3(AvalonMinerMake):
     expected_chips = 10
     expected_fans = 1
     algo = MinerAlgo.SHA256
+
+class AvalonNano3s(AvalonMinerMake):
+    raw_model = MinerModel.AVALONMINER.AvalonNano3s
+
+    expected_hashboards = 1
+    expected_chips = 10
+    expected_fans = 1
+    algo = MinerAlgo.SHA256

--- a/pyasic/miners/device/models/avalonminer/nano/nano3.py
+++ b/pyasic/miners/device/models/avalonminer/nano/nano3.py
@@ -15,6 +15,6 @@ class AvalonNano3s(AvalonMinerMake):
     raw_model = MinerModel.AVALONMINER.AvalonNano3s
 
     expected_hashboards = 1
-    expected_chips = 10
+    expected_chips = 12
     expected_fans = 1
     algo = MinerAlgo.SHA256

--- a/pyasic/miners/device/models/avalonminer/nano/nano3.py
+++ b/pyasic/miners/device/models/avalonminer/nano/nano3.py
@@ -11,6 +11,7 @@ class AvalonNano3(AvalonMinerMake):
     expected_fans = 1
     algo = MinerAlgo.SHA256
 
+
 class AvalonNano3s(AvalonMinerMake):
     raw_model = MinerModel.AVALONMINER.AvalonNano3s
 

--- a/pyasic/miners/factory.py
+++ b/pyasic/miners/factory.py
@@ -506,6 +506,7 @@ MINER_CLASSES = {
         "AVALONMINER 1166PRO": CGMinerAvalon1166Pro,
         "AVALONMINER 1246": CGMinerAvalon1246,
         "AVALONMINER NANO3": CGMinerAvalonNano3,
+        "AVALON NANO3S": CGMinerAvalonNano3s,
         "AVALONMINER 15-194": CGMinerAvalon1566,
     },
     MinerTypes.INNOSILICON: {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyasic"
-version = "0.72.4"
+version = "0.72.5"
 
 description = "A simplified and standardized interface for Bitcoin ASICs."
 authors = [{name = "UpstreamData", email = "brett@upstreamdata.ca"}]


### PR DESCRIPTION
Adds support for Avalon Nano3s.

Example output:
![image](https://github.com/user-attachments/assets/5d4e3d9e-a46a-4a7b-98c0-6fd9b0b4ed1e)
