### PR TITLE
fix: nano3s Efficiency and Hashrate Fixes

### DIFF
--- a/pyasic/miners/avalonminer/cgminer/nano/nano3.py
+++ b/pyasic/miners/avalonminer/cgminer/nano/nano3.py
@@ -13,9 +13,11 @@
 #  See the License for the specific language governing permissions and         -
 #  limitations under the License.                                              -
 # ------------------------------------------------------------------------------
-from typing import Optional
+from typing import List, Optional
 
 from pyasic import APIError
+from pyasic.data.boards import HashBoard
+from pyasic.device.algorithm.hashrate import AlgoHashRate
 from pyasic.miners.backends import AvalonMiner
 from pyasic.miners.data import (
     DataFunction,
@@ -84,6 +86,62 @@ AVALON_NANO_DATA_LOC = DataLocations(
     }
 )
 
+AVALON_NANO3S_DATA_LOC = DataLocations(
+    **{
+        str(DataOptions.MAC): DataFunction(
+            "_get_mac",
+            [RPCAPICommand("rpc_version", "version")],
+        ),
+        str(DataOptions.API_VERSION): DataFunction(
+            "_get_api_ver",
+            [RPCAPICommand("rpc_version", "version")],
+        ),
+        str(DataOptions.FW_VERSION): DataFunction(
+            "_get_fw_ver",
+            [RPCAPICommand("rpc_version", "version")],
+        ),
+        str(DataOptions.HASHRATE): DataFunction(
+            "_get_hashrate",
+            [RPCAPICommand("rpc_stats", "stats")],
+        ),
+        str(DataOptions.EXPECTED_HASHRATE): DataFunction(
+            "_get_expected_hashrate",
+            [RPCAPICommand("rpc_stats", "stats")],
+        ),
+        str(DataOptions.HASHBOARDS): DataFunction(
+            "_get_hashboards",
+            [RPCAPICommand("rpc_stats", "stats")],
+        ),
+        str(DataOptions.ENVIRONMENT_TEMP): DataFunction(
+            "_get_env_temp",
+            [RPCAPICommand("rpc_stats", "stats")],
+        ),
+        str(DataOptions.WATTAGE_LIMIT): DataFunction(
+            "_get_wattage_limit",
+            [RPCAPICommand("rpc_stats", "stats")],
+        ),
+        str(DataOptions.WATTAGE): DataFunction(
+            "_get_wattage",
+            [RPCAPICommand("rpc_stats", "stats")],
+        ),
+        str(DataOptions.FANS): DataFunction(
+            "_get_fans",
+            [RPCAPICommand("rpc_stats", "stats")],
+        ),
+        str(DataOptions.FAULT_LIGHT): DataFunction(
+            "_get_fault_light",
+            [RPCAPICommand("rpc_stats", "stats")],
+        ),
+        str(DataOptions.UPTIME): DataFunction(
+            "_get_uptime",
+            [RPCAPICommand("rpc_stats", "stats")],
+        ),
+        str(DataOptions.POOLS): DataFunction(
+            "_get_pools",
+            [RPCAPICommand("rpc_pools", "pools")],
+        ),
+    }
+)
 
 class CGMinerAvalonNano3(AvalonMiner, AvalonNano3):
     _web_cls = AvalonMinerWebAPI
@@ -108,4 +166,65 @@ class CGMinerAvalonNano3(AvalonMiner, AvalonNano3):
 
 
 class CGMinerAvalonNano3s(AvalonMiner, AvalonNano3s):
-    pass
+
+    data_locations = AVALON_NANO3S_DATA_LOC
+
+    async def _get_wattage(self, rpc_stats: dict = None) -> Optional[int]:
+        if rpc_stats is None:
+            try:
+                rpc_stats = await self.rpc.stats()
+            except APIError:
+                pass
+
+        if rpc_stats is not None:
+            try:
+                unparsed_stats = rpc_stats["STATS"][0]["MM ID0"]
+                parsed_stats = self.parse_stats(unparsed_stats)
+                return int(parsed_stats["PS"][6])
+            except (IndexError, KeyError, ValueError, TypeError):
+                pass
+
+    async def _get_hashrate(self, rpc_stats: dict = None) -> Optional[AlgoHashRate]:
+        if rpc_stats is None:
+            try:
+                rpc_stats = await self.rpc.stats()
+            except APIError:
+                pass
+
+        if rpc_stats is not None:
+            try:
+                unparsed_stats = rpc_stats["STATS"][0]["MM ID0"]
+                parsed_stats = self.parse_stats(unparsed_stats)
+                return self.algo.hashrate(
+                    rate=float(parsed_stats["GHSspd"][0]), unit=self.algo.unit.GH
+                ).into(self.algo.unit.default)
+            except (IndexError, KeyError, ValueError, TypeError):
+                pass
+
+    async def _get_hashboards(self, rpc_stats: dict = None) -> List[HashBoard]:    
+        hashboards = await AvalonMiner._get_hashboards(self, rpc_stats)
+
+        if rpc_stats is None:
+            try:
+                rpc_stats = await self.rpc.stats()
+            except APIError:
+                pass
+
+        if rpc_stats is not None:
+
+            try:
+                unparsed_stats = rpc_stats["STATS"][0]["MM ID0"]
+                parsed_stats = self.parse_stats(unparsed_stats)
+            except (IndexError, KeyError, ValueError, TypeError):
+                return hashboards
+                
+            for board in range(len(hashboards)):
+                try:
+                    board_hr = parsed_stats["GHSspd"][board]
+                    hashboards[board].hashrate = self.algo.hashrate(
+                        rate=float(board_hr), unit=self.algo.unit.GH
+                    ).into(self.algo.unit.default)
+                except LookupError:
+                    pass
+
+        return hashboards

--- a/pyasic/miners/avalonminer/cgminer/nano/nano3.py
+++ b/pyasic/miners/avalonminer/cgminer/nano/nano3.py
@@ -143,6 +143,7 @@ AVALON_NANO3S_DATA_LOC = DataLocations(
     }
 )
 
+
 class CGMinerAvalonNano3(AvalonMiner, AvalonNano3):
     _web_cls = AvalonMinerWebAPI
     web: AvalonMinerWebAPI
@@ -201,7 +202,7 @@ class CGMinerAvalonNano3s(AvalonMiner, AvalonNano3s):
             except (IndexError, KeyError, ValueError, TypeError):
                 pass
 
-    async def _get_hashboards(self, rpc_stats: dict = None) -> List[HashBoard]:    
+    async def _get_hashboards(self, rpc_stats: dict = None) -> List[HashBoard]:
         hashboards = await AvalonMiner._get_hashboards(self, rpc_stats)
 
         if rpc_stats is None:
@@ -217,7 +218,7 @@ class CGMinerAvalonNano3s(AvalonMiner, AvalonNano3s):
                 parsed_stats = self.parse_stats(unparsed_stats)
             except (IndexError, KeyError, ValueError, TypeError):
                 return hashboards
-                
+
             for board in range(len(hashboards)):
                 try:
                     board_hr = parsed_stats["GHSspd"][board]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyasic"
-version = "0.72.6"
+version = "0.72.7"
 
 description = "A simplified and standardized interface for Bitcoin ASICs."
 authors = [{name = "UpstreamData", email = "brett@upstreamdata.ca"}]


### PR DESCRIPTION
**Efficiency Fix**
The efficiency field was not being populated from the get_data call. After investigating I found that the _get_wattage WALLPOWER field that is referenced in avalonminer.py is not populated by the nano3s. Reviewing the source for the avalon's web gui I found that the wallpower is actually being pulled from the power_info[6] field as shown [here](https://github.com/Canaan-Creative/Avalon_Nano3s/blob/04c84d312a4e38c1efa437b086bbcb297749e77a/cg_miner/cgminer/driver-avalon.c#L1228). The documentation for this field is described [here](https://github.com/Canaan-Creative/avalon10-docs/blob/master/Universal%20API/Avalon%20A10%20API%20manual-EN.md#29--query-hash-power-state).

**Hashrate Fix**
The hashrate returned by this library was not matching what was showing on the nano3 web gui. I found that the web gui is referencing the [GHSspd](https://github.com/Canaan-Creative/Avalon_Nano3s/blob/04c84d312a4e38c1efa437b086bbcb297749e77a/cg_miner/cgminer/driver-avalon.c#L1217) from the stats call rather than the MHS 1m from the devs call. This changes pyasic to use the same GHSspd for the hashrate in both the _get_hashrate and _get_hashboards calls.