### PR TITLE
Retry and Timeout Changes for espminer

### DIFF
--- a/pyasic/web/espminer.py
+++ b/pyasic/web/espminer.py
@@ -20,34 +20,36 @@ class ESPMinerWebAPI(BaseWebAPI):
         **parameters: Any,
     ) -> dict:
         url = f"http://{self.ip}:{self.port}/api/{command}"
-        try:
-            async with httpx.AsyncClient(
-                transport=settings.transport(),
-            ) as client:
-                if parameters.get("post", False):
-                    parameters.pop("post")
-                    data = await client.post(
-                        url,
-                        timeout=settings.get("api_function_timeout", 3),
-                        json=parameters,
-                    )
-                elif parameters.get("patch", False):
-                    parameters.pop("patch")
-                    data = await client.patch(
-                        url,
-                        timeout=settings.get("api_function_timeout", 3),
-                        json=parameters,
-                    )
-                else:
-                    data = await client.get(url)
-        except httpx.HTTPError:
-            pass
-        else:
-            if data.status_code == 200:
+        async with httpx.AsyncClient(transport=settings.transport()) as client:
+            for retry_cnt in range(settings.get("get_data_retries", 1)):
                 try:
-                    return data.json()
-                except json.decoder.JSONDecodeError:
+                    if parameters.get("post", False):
+                        parameters.pop("post")
+                        data = await client.post(
+                            url,
+                            timeout=settings.get("api_function_timeout", 3),
+                            json=parameters,
+                        )
+                    elif parameters.get("patch", False):
+                        parameters.pop("patch")
+                        data = await client.patch(
+                            url,
+                            timeout=settings.get("api_function_timeout", 3),
+                            json=parameters,
+                        )
+                    else:
+                        data = await client.get(
+                            url,
+                            timeout=settings.get("api_function_timeout", 5),
+                        )
+                except httpx.HTTPError:
                     pass
+                else:
+                    if data.status_code == 200:
+                        try:
+                            return data.json()
+                        except json.decoder.JSONDecodeError:
+                            pass
 
     async def multicommand(
         self, *commands: str, ignore_errors: bool = False, allow_warning: bool = True

--- a/pyasic/web/espminer.py
+++ b/pyasic/web/espminer.py
@@ -21,7 +21,7 @@ class ESPMinerWebAPI(BaseWebAPI):
     ) -> dict:
         url = f"http://{self.ip}:{self.port}/api/{command}"
         async with httpx.AsyncClient(transport=settings.transport()) as client:
-            for retry_cnt in range(settings.get("get_data_retries", 1)):
+            for _ in range(settings.get("get_data_retries", 1)):
                 try:
                     if parameters.get("post", False):
                         parameters.pop("post")


### PR DESCRIPTION
Adds retry logic and get timeout support for espminer send_command. Looked at the web/goldshell.py/send_command as an example. The lucky miner lv08 sometimes gets timeout errors on get_data, this is an attempt to resolve that.