### PR TITLE
Fix API Issue with Bitaxe Miners

### DIFF
--- a/pyasic/miners/backends/espminer.py
+++ b/pyasic/miners/backends/espminer.py
@@ -115,23 +115,17 @@ class ESPMiner(BaseMiner):
 
         if web_system_info is not None:
             try:
-
-                # Right now the issue is that one of these values is returning None, but according to the docs, they should be there.
-                # https://osmu.wiki/bitaxe/api/
-
                 small_core_count = web_system_info.get("smallCoreCount")
                 asic_count = web_system_info.get("asicCount")
                 frequency = web_system_info.get("frequency")
 
                 if asic_count is None:
-                    print("[espminer]: asicCount not found in system info dict.")
-                    return None
-                if frequency is None:
-                    print("[espminer]: frequency not found in system info dict.")
-                    return None
-                if small_core_count is None:
-                    print("[espminer]: smallCoreCount not found in system info dict.")
-                    return None
+                    try:
+                        asic_info = await self.web.asic_info()
+                        asic_count = asic_info.get("asicCount")
+                    except APIError:
+                        pass
+
 
                 expected_hashrate = (
                     small_core_count

--- a/pyasic/miners/backends/espminer.py
+++ b/pyasic/miners/backends/espminer.py
@@ -115,10 +115,28 @@ class ESPMiner(BaseMiner):
 
         if web_system_info is not None:
             try:
+
+                # Right now the issue is that one of these values is returning None, but according to the docs, they should be there.
+                # https://osmu.wiki/bitaxe/api/
+
+                small_core_count = web_system_info.get("smallCoreCount")
+                asic_count = web_system_info.get("asicCount")
+                frequency = web_system_info.get("frequency")
+
+                if asic_count is None:
+                    print("Warning: 'asicCount' not found in system info dict.")
+                    return None
+                if frequency is None:
+                    print("Warning: 'frequency' not found in system info dict.")
+                    return None
+                if small_core_count is None:
+                    print("Warning: 'smallCoreCount' not found in system info dict.")
+                    return None
+
                 expected_hashrate = (
-                    web_system_info.get("smallCoreCount")
-                    * web_system_info.get("asicCount")
-                    * web_system_info.get("frequency")
+                    small_core_count
+                    * asic_count
+                    * frequency
                 )
 
                 return self.algo.hashrate(

--- a/pyasic/miners/backends/espminer.py
+++ b/pyasic/miners/backends/espminer.py
@@ -124,13 +124,13 @@ class ESPMiner(BaseMiner):
                 frequency = web_system_info.get("frequency")
 
                 if asic_count is None:
-                    print("Warning: 'asicCount' not found in system info dict.")
+                    print("[espminer]: asicCount not found in system info dict.")
                     return None
                 if frequency is None:
-                    print("Warning: 'frequency' not found in system info dict.")
+                    print("[espminer]: frequency not found in system info dict.")
                     return None
                 if small_core_count is None:
-                    print("Warning: 'smallCoreCount' not found in system info dict.")
+                    print("[espminer]: smallCoreCount not found in system info dict.")
                     return None
 
                 expected_hashrate = (
@@ -150,7 +150,7 @@ class ESPMiner(BaseMiner):
             try:
                 web_system_info = await self.web.system_info()
             except APIError:
-                pass
+                pass   
 
         if web_system_info is not None:
             try:

--- a/pyasic/web/espminer.py
+++ b/pyasic/web/espminer.py
@@ -96,3 +96,6 @@ class ESPMinerWebAPI(BaseWebAPI):
 
     async def update_settings(self, **config):
         return await self.send_command("system", patch=True, **config)
+
+    async def asic_info(self):
+        return await self.send_command("system/asic")


### PR DESCRIPTION
In the most recent firmware update, bitaxe moved the asicCount field that was found in `/system/info` into `/system/asic`, which made `_get_expected_hashrate()` fail. Now if asicCount returns None, we check to see if we can find it in `/system/asic`