### PR TITLE
Goldshell Byte Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pyvenv.cfg
 bin/
 lib/
 .idea/
+.vs/

--- a/docs/miners/goldshell/Byte.md
+++ b/docs/miners/goldshell/Byte.md
@@ -1,0 +1,16 @@
+# pyasic
+## Byte Models
+
+## Byte (Stock)
+
+- [x] Shutdowns
+- [ ] Power Modes
+- [ ] Setpoints
+- [ ] Presets
+
+::: pyasic.miners.goldshell.bfgminer.Byte.Byte.GoldshellByte
+    handler: python
+    options:
+        show_root_heading: false
+        heading_level: 0
+

--- a/docs/miners/supported_types.md
+++ b/docs/miners/supported_types.md
@@ -601,6 +601,12 @@ details {
 <summary>Stock Firmware Goldshells:</summary>
     <ul>
         <details>
+            <summary>Byte Series:</summary>
+                <ul>
+                    <li><a href="../goldshell/Byte#byte-stock">Byte (Stock)</a></li>
+                </ul>
+        </details>
+        <details>
             <summary>X5 Series:</summary>
                 <ul>
                     <li><a href="../goldshell/X5#ck5-stock">CK5 (Stock)</a></li>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
         - Innosilicon T3X: "miners/innosilicon/T3X.md"
         - Innosilicon A10X: "miners/innosilicon/A10X.md"
         - Innosilicon A11X: "miners/innosilicon/A11X.md"
+        - Goldshell Byte: "miners/goldshell/Byte.md"
         - Goldshell X5: "miners/goldshell/X5.md"
         - Goldshell XMax: "miners/goldshell/XMax.md"
         - Goldshell XBox: "miners/goldshell/XBox.md"

--- a/pyasic/config/__init__.py
+++ b/pyasic/config/__init__.py
@@ -248,6 +248,11 @@ class MinerConfig(BaseModel):
         return cls(pools=PoolConfig.from_am_modern(web_conf))
 
     @classmethod
+    def from_goldshell_byte(cls, web_conf: dict) -> "MinerConfig":
+        """Constructs a MinerConfig object from web configuration for Goldshell Byte miners."""
+        return cls(pools=PoolConfig.from_goldshell_byte(web_conf))
+
+    @classmethod
     def from_inno(cls, web_pools: list) -> "MinerConfig":
         """Constructs a MinerConfig object from web configuration for Innosilicon miners."""
         return cls(pools=PoolConfig.from_inno(web_pools))

--- a/pyasic/config/pools.py
+++ b/pyasic/config/pools.py
@@ -632,6 +632,16 @@ class PoolConfig(MinerConfigValue):
         return cls(groups=[PoolGroup.from_goldshell(web_pools)])
 
     @classmethod
+    def from_goldshell_byte(cls, web_pools: list) -> "PoolConfig":
+        return cls(
+            groups=[
+                PoolGroup.from_goldshell(g["pools"])
+                for g in web_pools
+                if len(g["pools"]) > 0
+            ]
+        )
+
+    @classmethod
     def from_inno(cls, web_pools: list) -> "PoolConfig":
         return cls(groups=[PoolGroup.from_inno(web_pools)])
 

--- a/pyasic/device/algorithm/__init__.py
+++ b/pyasic/device/algorithm/__init__.py
@@ -12,6 +12,7 @@ from .kheavyhash import KHeavyHashAlgo
 from .scrypt import ScryptAlgo
 from .sha256 import SHA256Algo
 from .x11 import X11Algo
+from .zksnark import ZkSnarkAlgo
 
 
 class MinerAlgo:
@@ -26,3 +27,4 @@ class MinerAlgo:
     ETHASH = EtHashAlgo
     EQUIHASH = EquihashAlgo
     BLOCKFLOW = BlockFlowAlgo
+    ZKSNARK = ZkSnarkAlgo

--- a/pyasic/device/algorithm/hashrate/__init__.py
+++ b/pyasic/device/algorithm/hashrate/__init__.py
@@ -10,6 +10,7 @@ from .kheavyhash import KHeavyHashHashRate
 from .scrypt import ScryptHashRate
 from .sha256 import SHA256HashRate
 from .x11 import X11HashRate
+from .zksnark import ZkSnarkHashRate
 
 
 class AlgoHashRate:
@@ -24,3 +25,4 @@ class AlgoHashRate:
     ETHASH = EtHashHashRate
     EQUIHASH = EquihashHashRate
     BLOCKFLOW = BlockFlowHashRate
+    ZKSNARK = ZkSnarkHashRate

--- a/pyasic/device/algorithm/hashrate/unit/__init__.py
+++ b/pyasic/device/algorithm/hashrate/unit/__init__.py
@@ -9,6 +9,7 @@ from .kheavyhash import KHeavyHashUnit
 from .scrypt import ScryptUnit
 from .sha256 import SHA256Unit
 from .x11 import X11Unit
+from .zksnark import ZkSnarkUnit
 
 
 class HashUnit:
@@ -23,3 +24,4 @@ class HashUnit:
     ETHASH = EtHashUnit
     EQUIHASH = EquihashUnit
     BLOCKFLOW = BlockFlowUnit
+    ZKSNARK = ZkSnarkUnit

--- a/pyasic/device/algorithm/hashrate/unit/zksnark.py
+++ b/pyasic/device/algorithm/hashrate/unit/zksnark.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from .base import AlgoHashRateUnitType
+
+
+class ZkSnarkUnit(AlgoHashRateUnitType):
+    H = 1
+    KH = int(H) * 1000
+    MH = int(KH) * 1000
+    GH = int(MH) * 1000
+    TH = int(GH) * 1000
+    PH = int(TH) * 1000
+    EH = int(PH) * 1000
+    ZH = int(EH) * 1000
+
+    default = GH

--- a/pyasic/device/algorithm/hashrate/zksnark.py
+++ b/pyasic/device/algorithm/hashrate/zksnark.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing_extensions import Self
+
+from pyasic.device.algorithm.hashrate.base import AlgoHashRateType
+from pyasic.device.algorithm.hashrate.unit.zksnark import ZkSnarkUnit
+
+from .unit import HashUnit
+
+
+class ZkSnarkHashRate(AlgoHashRateType):
+    rate: float
+    unit: ZkSnarkUnit = HashUnit.ZKSNARK.default
+
+    def into(self, other: ZkSnarkUnit) -> Self:
+        return self.__class__(
+            rate=self.rate / (other.value / self.unit.value), unit=other
+        )

--- a/pyasic/device/algorithm/zksnark.py
+++ b/pyasic/device/algorithm/zksnark.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from .base import MinerAlgoType
+from .hashrate import ZkSnarkHashRate
+from .hashrate.unit import ZkSnarkUnit
+
+
+class ZkSnarkAlgo(MinerAlgoType):
+    hashrate: type[ZkSnarkHashRate] = ZkSnarkHashRate
+    unit: type[ZkSnarkUnit] = ZkSnarkUnit
+
+    name = "zkSNARK"

--- a/pyasic/device/models.py
+++ b/pyasic/device/models.py
@@ -479,6 +479,7 @@ class GoldshellModels(MinerModelType):
     KDMax = "KD Max"
     KDBoxII = "KD Box II"
     KDBoxPro = "KD Box Pro"
+    Byte = "Byte"
 
     def __str__(self):
         return self.value

--- a/pyasic/miners/device/models/goldshell/Byte/Byte.py
+++ b/pyasic/miners/device/models/goldshell/Byte/Byte.py
@@ -13,7 +13,15 @@
 #  See the License for the specific language governing permissions and         -
 #  limitations under the License.                                              -
 # ------------------------------------------------------------------------------
-from .Byte import *
-from .X5 import *
-from .XBox import *
-from .XMax import *
+from pyasic.device.algorithm.base import GenericAlgo
+from pyasic.device.models import MinerModel
+from pyasic.miners.device.makes import GoldshellMake
+
+
+class Byte(GoldshellMake):
+    raw_model = MinerModel.GOLDSHELL.Byte
+
+    expected_chips = 0
+    expected_fans = 0
+    expected_hashboards = 0
+    algo = GenericAlgo

--- a/pyasic/miners/device/models/goldshell/Byte/__init__.py
+++ b/pyasic/miners/device/models/goldshell/Byte/__init__.py
@@ -13,7 +13,4 @@
 #  See the License for the specific language governing permissions and         -
 #  limitations under the License.                                              -
 # ------------------------------------------------------------------------------
-from .Byte import *
-from .X5 import *
-from .XBox import *
-from .XMax import *
+from .Byte import Byte

--- a/pyasic/miners/device/models/goldshell/__init__.py
+++ b/pyasic/miners/device/models/goldshell/__init__.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and         -
 #  limitations under the License.                                              -
 # ------------------------------------------------------------------------------
+from .Byte import *
 from .X5 import *
 from .XBox import *
 from .XMax import *

--- a/pyasic/miners/factory.py
+++ b/pyasic/miners/factory.py
@@ -529,6 +529,7 @@ MINER_CLASSES = {
         "GOLDSHELL KDMAX": GoldshellKDMax,
         "GOLDSHELL KDBOXII": GoldshellKDBoxII,
         "GOLDSHELL KDBOXPRO": GoldshellKDBoxPro,
+        "GOLDSHELL BYTE": GoldshellByte,
     },
     MinerTypes.BRAIINS_OS: {
         None: BOSMiner,

--- a/pyasic/miners/goldshell/bfgminer/Byte/Byte.py
+++ b/pyasic/miners/goldshell/bfgminer/Byte/Byte.py
@@ -1,0 +1,319 @@
+# ------------------------------------------------------------------------------
+#  Copyright 2022 Upstream Data Inc                                            -
+#                                                                              -
+#  Licensed under the Apache License, Version 2.0 (the "License");             -
+#  you may not use this file except in compliance with the License.            -
+#  You may obtain a copy of the License at                                     -
+#                                                                              -
+#      http://www.apache.org/licenses/LICENSE-2.0                              -
+#                                                                              -
+#  Unless required by applicable law or agreed to in writing, software         -
+#  distributed under the License is distributed on an "AS IS" BASIS,           -
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    -
+#  See the License for the specific language governing permissions and         -
+#  limitations under the License.                                              -
+# ------------------------------------------------------------------------------
+from typing import List, Optional, Union
+
+from pyasic.config import MinerConfig
+from pyasic.data import Fan, MinerData
+from pyasic.data.boards import HashBoard
+from pyasic.data.pools import PoolMetrics, PoolUrl
+from pyasic.device.algorithm import AlgoHashRate, MinerAlgo
+from pyasic.errors import APIError
+from pyasic.miners.backends import GoldshellMiner
+from pyasic.miners.data import (
+    DataFunction,
+    DataLocations,
+    DataOptions,
+    RPCAPICommand,
+    WebAPICommand,
+)
+from pyasic.miners.device.models import Byte
+
+ALGORITHM_SCRYPT_NAME = "scrypt(LTC)"
+ALGORITHM_ZKSNARK_NAME = "zkSNARK(ALEO)"
+EXPECTED_CHIPS_PER_SCRYPT_BOARD = 5
+EXPECTED_CHIPS_PER_ZKSNARK_BOARD = 3
+
+GOLDSHELL_BYTE_DATA_LOC = DataLocations(
+    **{
+        str(DataOptions.MAC): DataFunction(
+            "_get_mac",
+            [WebAPICommand("web_setting", "setting")],
+        ),
+        str(DataOptions.API_VERSION): DataFunction(
+            "_get_api_ver",
+            [WebAPICommand("web_setting", "version")],
+        ),
+        str(DataOptions.FW_VERSION): DataFunction(
+            "_get_fw_ver",
+            [WebAPICommand("web_status", "status")],
+        ),
+        str(DataOptions.HASHRATE): DataFunction(
+            "_get_hashrate",
+            [RPCAPICommand("rpc_devs", "devs")],
+        ),
+        str(DataOptions.EXPECTED_HASHRATE): DataFunction(
+            "_get_expected_hashrate",
+            [RPCAPICommand("rpc_devs", "devs")],
+        ),
+        str(DataOptions.HASHBOARDS): DataFunction(
+            "_get_hashboards",
+            [
+                RPCAPICommand("rpc_devs", "devs"),
+                RPCAPICommand("rpc_devdetails", "devdetails"),
+            ],
+        ),
+        str(DataOptions.FANS): DataFunction(
+            "_get_fans",
+            [RPCAPICommand("rpc_devs", "devs")],
+        ),
+        str(DataOptions.POOLS): DataFunction(
+            "_get_pools",
+            [RPCAPICommand("rpc_pools", "pools")],
+        ),
+    }
+)
+
+
+class GoldshellByte(GoldshellMiner, Byte):
+
+    data_locations = GOLDSHELL_BYTE_DATA_LOC
+
+    cgdev: dict | None = None
+
+    async def get_data(
+        self,
+        allow_warning: bool = False,
+        include: List[Union[str, DataOptions]] = None,
+        exclude: List[Union[str, DataOptions]] = None,
+    ) -> MinerData:
+        if self.cgdev is None:
+            try:
+                self.cgdev = await self.web.send_command("cgminer?cgminercmd=devs")
+            except APIError:
+                pass
+
+        scrypt_board_count = 0
+        zksnark_board_count = 0
+        total_wattage = 0
+        total_uptime_mins = 0
+
+        for minfo in self.cgdev.get("minfos", []):
+
+            algo_name = minfo.get("name")
+
+            for info in minfo.get("infos", []):
+
+                self.expected_hashboards += 1
+                self.expected_fans += 1
+
+                total_wattage = int(float(info.get("power", 0)))
+                total_uptime_mins = int(info.get("time", 0))
+
+                if algo_name == ALGORITHM_SCRYPT_NAME:
+                    scrypt_board_count += 1
+                elif algo_name == ALGORITHM_ZKSNARK_NAME:
+                    zksnark_board_count += 1
+
+        self.expected_chips = (EXPECTED_CHIPS_PER_SCRYPT_BOARD * scrypt_board_count) + (
+            EXPECTED_CHIPS_PER_ZKSNARK_BOARD * zksnark_board_count
+        )
+
+        if scrypt_board_count > 0 and zksnark_board_count == 0:
+            self.algo = MinerAlgo.SCRYPT
+        elif zksnark_board_count > 0 and scrypt_board_count == 0:
+            self.algo = MinerAlgo.ZKSNARK
+
+        data = await super().get_data(allow_warning, include, exclude)
+        data.expected_chips = self.expected_chips
+        data.wattage = total_wattage
+        data.uptime = total_uptime_mins
+        data.voltage = 0
+
+        for board in data.hashboards:
+            data.voltage += board.voltage
+
+        return data
+
+    async def get_config(self) -> MinerConfig:
+        try:
+            pools = await self.web.pools()
+        except APIError:
+            return self.config
+
+        self.config = MinerConfig.from_goldshell_byte(pools)
+        return self.config
+
+    async def _get_api_ver(self, web_setting: dict = None) -> Optional[str]:
+        if web_setting is None:
+            try:
+                web_setting = await self.web.setting()
+            except APIError:
+                pass
+
+        if web_setting is not None:
+            try:
+                version = web_setting.get("version")
+                if version is not None:
+                    self.api_ver = version.strip("v")
+                    return self.api_ver
+            except KeyError:
+                pass
+
+        return self.api_ver
+
+    async def _get_expected_hashrate(
+        self, rpc_devs: dict = None
+    ) -> Optional[AlgoHashRate]:
+        if rpc_devs is None:
+            try:
+                rpc_devs = await self.rpc.devs()
+            except APIError:
+                pass
+
+        total_hash_rate_mh = 0
+
+        if rpc_devs is not None:
+            for board in rpc_devs.get("DEVS", []):
+
+                algo_name = board.get("pool")
+
+                if algo_name == ALGORITHM_SCRYPT_NAME:
+                    total_hash_rate_mh += (
+                        self.algo.hashrate(
+                            rate=float(board.get("estimate_hash_rate", 0)),
+                            unit=self.algo.unit.H,
+                        )
+                        .into(self.algo.unit.MH)
+                        .rate
+                    )
+                elif algo_name == ALGORITHM_ZKSNARK_NAME:
+                    total_hash_rate_mh += float(board.get("theory_hash", 0))
+
+        hash_rate = self.algo.hashrate(
+            rate=total_hash_rate_mh, unit=self.algo.unit.MH
+        ).into(self.algo.unit.default)
+
+        return hash_rate
+
+    async def _get_hashrate(self, rpc_devs: dict = None) -> Optional[AlgoHashRate]:
+        if rpc_devs is None:
+            try:
+                rpc_devs = await self.rpc.devs()
+            except APIError:
+                pass
+
+        total_hash_rate_mh = 0
+
+        if rpc_devs is not None:
+            for board in rpc_devs.get("DEVS", []):
+                total_hash_rate_mh += float(board.get("MHS 20s", 0))
+
+        hash_rate = self.algo.hashrate(
+            rate=total_hash_rate_mh, unit=self.algo.unit.MH
+        ).into(self.algo.unit.default)
+
+        return hash_rate
+
+    async def _get_pools(self, rpc_pools: dict = None) -> List[PoolMetrics]:
+        if rpc_pools is None:
+            try:
+                rpc_pools = await self.rpc.pools()
+            except APIError:
+                pass
+
+        pools_data = []
+        if rpc_pools is not None:
+            try:
+                pools = rpc_pools.get("POOLS", [])
+                for index, pool_info in enumerate(pools):
+                    url = pool_info.get("URL")
+                    pool_url = PoolUrl.from_str(url) if url else None
+                    pool_data = PoolMetrics(
+                        accepted=pool_info.get("Accepted"),
+                        rejected=pool_info.get("Rejected"),
+                        active=pool_info.get("Stratum Active"),
+                        alive=pool_info.get("Status") == "Alive",
+                        url=pool_url,
+                        user=pool_info.get("User"),
+                        index=index,
+                    )
+                    pools_data.append(pool_data)
+            except LookupError:
+                pass
+        return pools_data
+
+    async def _get_hashboards(
+        self, rpc_devs: dict = None, rpc_devdetails: dict = None
+    ) -> List[HashBoard]:
+        if rpc_devs is None:
+            try:
+                rpc_devs = await self.rpc.devs()
+            except APIError:
+                pass
+
+        hashboards = [
+            HashBoard(slot=i, expected_chips=self.expected_chips)
+            for i in range(self.expected_hashboards)
+        ]
+
+        if rpc_devs is not None:
+            for board in rpc_devs.get("DEVS", []):
+                b_id = board["PGA"]
+                hashboards[b_id].hashrate = self.algo.hashrate(
+                    rate=float(board["MHS 20s"]), unit=self.algo.unit.MH
+                ).into(self.algo.unit.default)
+                hashboards[b_id].chip_temp = board["tstemp-1"]
+                hashboards[b_id].temp = board["tstemp-2"]
+                hashboards[b_id].voltage = board["voltage"]
+                hashboards[b_id].active = board["Status"] == "Alive"
+                hashboards[b_id].missing = False
+
+                algo_name = board.get("pool")
+
+                if algo_name == ALGORITHM_SCRYPT_NAME:
+                    hashboards[b_id].expected_chips = EXPECTED_CHIPS_PER_SCRYPT_BOARD
+                elif algo_name == ALGORITHM_ZKSNARK_NAME:
+                    hashboards[b_id].expected_chips = EXPECTED_CHIPS_PER_ZKSNARK_BOARD
+
+        if rpc_devdetails is None:
+            try:
+                rpc_devdetails = await self.rpc.devdetails()
+            except APIError:
+                pass
+
+        if rpc_devdetails is not None:
+            for board in rpc_devdetails.get("DEVS", []):
+                b_id = board["DEVDETAILS"]
+                hashboards[b_id].chips = board["chips-nr"]
+
+        return hashboards
+
+    async def _get_fans(self, rpc_devs: dict = None) -> List[Fan]:
+        if self.expected_fans is None:
+            return []
+
+        if rpc_devs is None:
+            try:
+                rpc_devs = await self.rpc.devs()
+            except APIError:
+                pass
+
+        fans_data = []
+
+        if rpc_devs is not None:
+            for board in rpc_devs.get("DEVS", []):
+                if board.get("PGA") is not None:
+                    try:
+                        b_id = board["PGA"]
+                        fan_speed = board[f"fan{b_id}"]
+                        fans_data.append(fan_speed)
+
+                    except KeyError:
+                        pass
+
+        fans = [Fan(speed=d) if d else Fan() for d in fans_data]
+
+        return fans

--- a/pyasic/miners/goldshell/bfgminer/Byte/__init__.py
+++ b/pyasic/miners/goldshell/bfgminer/Byte/__init__.py
@@ -13,7 +13,4 @@
 #  See the License for the specific language governing permissions and         -
 #  limitations under the License.                                              -
 # ------------------------------------------------------------------------------
-from .Byte import *
-from .X5 import *
-from .XBox import *
-from .XMax import *
+from .Byte import GoldshellByte


### PR DESCRIPTION
This adds support for the Goldshell Byte. The Byte is unique in that it supports 0 to 2 cards that can have different algorithms. Currently it supports Scrypt and zkSNARK (Aleo) algorithms. Each card has its own unique number of chips, so we need to do some various calculations based on which card we are looking at. Note that when there are no cards attached various apis are not available, so we don't get all of the base data. When there is one of each card type it uses the default Generic algo.