### PR TITLE
Avalon Nano3s Fixes

### DIFF
--- a/pyasic/miners/avalonminer/cgminer/nano/nano3.py
+++ b/pyasic/miners/avalonminer/cgminer/nano/nano3.py
@@ -178,8 +178,7 @@ class CGMinerAvalonNano3s(AvalonMiner, AvalonNano3s):
 
         if rpc_estats is not None:
             try:
-                unparsed_estats = rpc_estats["STATS"][0]["MM ID0"]
-                parsed_estats = self.parse_estats(unparsed_estats)
+                parsed_estats = self.parse_estats(rpc_estats)["STATS"][0]["MM ID0"]
                 return int(parsed_estats["PS"][6])
             except (IndexError, KeyError, ValueError, TypeError):
                 pass
@@ -193,8 +192,7 @@ class CGMinerAvalonNano3s(AvalonMiner, AvalonNano3s):
 
         if rpc_estats is not None:
             try:
-                unparsed_estats = rpc_estats["STATS"][0]["MM ID0"]
-                parsed_estats = self.parse_estats(unparsed_estats)
+                parsed_estats = self.parse_estats(rpc_estats)["STATS"][0]["MM ID0"]
                 return self.algo.hashrate(
                     rate=float(parsed_estats["GHSspd"]), unit=self.algo.unit.GH
                 ).into(self.algo.unit.default)
@@ -212,14 +210,13 @@ class CGMinerAvalonNano3s(AvalonMiner, AvalonNano3s):
 
         if rpc_estats is not None:
             try:
-                unparsed_estats = rpc_estats["STATS"][0]["MM ID0"]
-                parsed_estats = self.parse_estats(unparsed_estats)
+                parsed_estats = self.parse_estats(rpc_estats)["STATS"][0]["MM ID0"]
             except (IndexError, KeyError, ValueError, TypeError):
                 return hashboards
 
             for board in range(len(hashboards)):
                 try:
-                    board_hr = parsed_estats["GHSspd"][board]
+                    board_hr = parsed_estats["GHSspd"]
                     hashboards[board].hashrate = self.algo.hashrate(
                         rate=float(board_hr), unit=self.algo.unit.GH
                     ).into(self.algo.unit.default)

--- a/pyasic/miners/backends/avalonminer.py
+++ b/pyasic/miners/backends/avalonminer.py
@@ -305,10 +305,10 @@ class AvalonMiner(CGMiner):
                     hashboards[board].chip_temp = int(
                         parsed_estats["STATS"][0]["MM ID0"]["MTmax"][board]
                     )
-                except LookupError:
+                except (LookupError, TypeError):
                     try:
                         hashboards[board].chip_temp = int(
-                            parsed_estats["STATS"][0]["MM ID0"]["Tmax"]
+                            parsed_estats["STATS"][0]["MM ID0"]["MTmax"]
                         )
                     except LookupError:
                         pass
@@ -317,10 +317,10 @@ class AvalonMiner(CGMiner):
                     hashboards[board].temp = int(
                         parsed_estats["STATS"][0]["MM ID0"]["MTmax"][board]
                     )
-                except LookupError:
+                except (LookupError, TypeError):
                     try:
                         hashboards[board].temp = int(
-                            parsed_estats["STATS"][0]["MM ID0"]["Tavg"]
+                            parsed_estats["STATS"][0]["MM ID0"]["MTavg"]
                         )
                     except LookupError:
                         pass
@@ -329,7 +329,7 @@ class AvalonMiner(CGMiner):
                     hashboards[board].inlet_temp = int(
                         parsed_estats["STATS"][0]["MM ID0"]["MTavg"][board]
                     )
-                except LookupError:
+                except (LookupError, TypeError):
                     try:
                         hashboards[board].inlet_temp = int(
                             parsed_estats["STATS"][0]["MM ID0"]["HBITemp"]
@@ -341,7 +341,7 @@ class AvalonMiner(CGMiner):
                     hashboards[board].outlet_temp = int(
                         parsed_estats["STATS"][0]["MM ID0"]["MTmax"][board]
                     )
-                except LookupError:
+                except (LookupError, TypeError):
                     try:
                         hashboards[board].outlet_temp = int(
                             parsed_estats["STATS"][0]["MM ID0"]["HBOTemp"]
@@ -356,7 +356,7 @@ class AvalonMiner(CGMiner):
                         hashboards[board].chips = len(
                             [item for item in chip_data if not item == "0"]
                         )
-                except LookupError:
+                except (LookupError, TypeError):
                     try:
                         chip_data = parsed_estats["STATS"][0]["HBinfo"][f"HB{board}"][
                             f"PVT_T{board}"

--- a/pyasic/miners/backends/avalonminer.py
+++ b/pyasic/miners/backends/avalonminer.py
@@ -308,7 +308,7 @@ class AvalonMiner(CGMiner):
                 except (LookupError, TypeError):
                     try:
                         hashboards[board].chip_temp = int(
-                            parsed_estats["STATS"][0]["MM ID0"]["MTmax"]
+                            parsed_estats["STATS"][0]["MM ID0"].get("Tmax", parsed_estats["STATS"][0]["MM ID0"]["TMax"])
                         )
                     except LookupError:
                         pass
@@ -320,7 +320,7 @@ class AvalonMiner(CGMiner):
                 except (LookupError, TypeError):
                     try:
                         hashboards[board].temp = int(
-                            parsed_estats["STATS"][0]["MM ID0"]["MTavg"]
+                            parsed_estats["STATS"][0]["MM ID0"].get("Tavg", parsed_estats["STATS"][0]["MM ID0"]["TAvg"])
                         )
                     except LookupError:
                         pass

--- a/pyasic/miners/backends/avalonminer.py
+++ b/pyasic/miners/backends/avalonminer.py
@@ -308,7 +308,9 @@ class AvalonMiner(CGMiner):
                 except (LookupError, TypeError):
                     try:
                         hashboards[board].chip_temp = int(
-                            parsed_estats["STATS"][0]["MM ID0"].get("Tmax", parsed_estats["STATS"][0]["MM ID0"]["TMax"])
+                            parsed_estats["STATS"][0]["MM ID0"].get(
+                                "Tmax", parsed_estats["STATS"][0]["MM ID0"]["TMax"]
+                            )
                         )
                     except LookupError:
                         pass
@@ -320,7 +322,9 @@ class AvalonMiner(CGMiner):
                 except (LookupError, TypeError):
                     try:
                         hashboards[board].temp = int(
-                            parsed_estats["STATS"][0]["MM ID0"].get("Tavg", parsed_estats["STATS"][0]["MM ID0"]["TAvg"])
+                            parsed_estats["STATS"][0]["MM ID0"].get(
+                                "Tavg", parsed_estats["STATS"][0]["MM ID0"]["TAvg"]
+                            )
                         )
                     except LookupError:
                         pass


### PR DESCRIPTION
This PR fixes issues introduced by [this commit](https://github.com/PixelByProxy/pyasic/commit/5457ae6cd5618ef8f2ffa0ed4aa5b27715e24a6c) for adding Avalon Q support. The main issues were:

1. _get_hashboards was not handling the TypeError so it would not fall back to the old logic if the value was not an array.
2. On the Nano3s the dictionary values are "TMax" and "TAvg" rather than "Tmax" and Tavg". Updated to handle both cases.
3. In CGMinerAvalonNano3s, the parse_estats was not using the correct value. It was passing in the string instead of the object.