### PR TITLE
Handle invalid unicode in json response

### DIFF
--- a/pyasic/rpc/base.py
+++ b/pyasic/rpc/base.py
@@ -253,10 +253,10 @@ If you are sure you want to use this command please use API.send_command("{comma
         # some json from the API returns with a null byte (\x00) on the end
         if data.endswith(b"\x00"):
             # handle the null byte
-            str_data = data.decode("utf-8")[:-1]
+            str_data = data.decode("utf-8", errors="replace")[:-1]
         else:
             # no null byte
-            str_data = data.decode("utf-8")
+            str_data = data.decode("utf-8", errors="replace")
         # fix an error with a btminer return having an extra comma that breaks json.loads()
         str_data = str_data.replace(",}", "}")
         # fix an error with a btminer return having a newline that breaks json.loads()


### PR DESCRIPTION
should fix:
```python
  File "/usr/lib/python3.13/site-packages/pyasic/miners/base.py", line 568, in get_data
  File "/usr/lib/python3.13/site-packages/pyasic/miners/base.py", line 489, in _get_data
  File "/usr/lib/python3.13/site-packages/pyasic/rpc/btminer.py", line 230, in multicommand
  File "/usr/lib/python3.13/site-packages/pyasic/rpc/base.py", line 89, in send_command
  File "/usr/lib/python3.13/site-packages/pyasic/rpc/base.py", line 259, in _load_api_data
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xaa in position 901: invalid start byte
```