### PR TITLE
Fix race condition in BOSer multicommand causing CancelledError

### DIFF
--- a/pyasic/web/braiins_os/boser.py
+++ b/pyasic/web/braiins_os/boser.py
@@ -84,13 +84,13 @@ class BOSerWebAPI(BaseWebAPI):
             except AttributeError:
                 pass
 
-        await asyncio.gather(*[t for t in tasks.values()], return_exceptions=True)
+        results = await asyncio.gather(
+            *[t for t in tasks.values()], return_exceptions=True
+        )
 
-        for cmd in tasks:
-            try:
-                result[cmd] = await tasks[cmd]
-            except (GRPCError, APIError, ConnectionError):
-                pass
+        for cmd, task_result in zip(tasks.keys(), results):
+            if not isinstance(task_result, (GRPCError, APIError, ConnectionError)):
+                result[cmd] = task_result
 
         return result
 


### PR DESCRIPTION
The multicommand method was double-awaiting tasks - first via asyncio.gather() with return_exceptions=True, then trying to await the same tasks again. This caused CancelledError when gRPC connections were lost.

Changed to properly use the results from gather() instead of re-awaiting completed tasks, preventing the race condition and properly handling exceptions.

Fixes StreamTerminatedError occurring in pyasic/web/braiins_os/boser.py:91