### PR TITLE
Fix race conditions in RPC and web API multicommand methods

### DIFF
--- a/pyasic/rpc/base.py
+++ b/pyasic/rpc/base.py
@@ -136,17 +136,16 @@ class BaseMinerRPCAPI:
                 self.send_command(cmd, allow_warning=allow_warning)
             )
 
-        await asyncio.gather(*[tasks[cmd] for cmd in tasks], return_exceptions=True)
+        results = await asyncio.gather(
+            *[tasks[cmd] for cmd in tasks], return_exceptions=True
+        )
 
         data = {}
-        for cmd in tasks:
-            try:
-                result = tasks[cmd].result()
+        for cmd, result in zip(tasks.keys(), results):
+            if not isinstance(result, (APIError, Exception)):
                 if result is None or result == {}:
                     result = {}
                 data[cmd] = [result]
-            except APIError:
-                pass
 
         return data
 

--- a/pyasic/web/auradine.py
+++ b/pyasic/web/auradine.py
@@ -141,17 +141,16 @@ class AuradineWebAPI(BaseWebAPI):
                 self.send_command(cmd, allow_warning=allow_warning)
             )
 
-        await asyncio.gather(*[tasks[cmd] for cmd in tasks], return_exceptions=True)
+        results = await asyncio.gather(
+            *[tasks[cmd] for cmd in tasks], return_exceptions=True
+        )
 
         data = {"multicommand": True}
-        for cmd in tasks:
-            try:
-                result = tasks[cmd].result()
+        for cmd, result in zip(tasks.keys(), results):
+            if not isinstance(result, (APIError, Exception)):
                 if result is None or result == {}:
                     result = {}
                 data[cmd] = result
-            except APIError:
-                pass
 
         return data
 

--- a/pyasic/web/espminer.py
+++ b/pyasic/web/espminer.py
@@ -71,17 +71,16 @@ class ESPMinerWebAPI(BaseWebAPI):
                 self.send_command(cmd, allow_warning=allow_warning)
             )
 
-        await asyncio.gather(*[tasks[cmd] for cmd in tasks], return_exceptions=True)
+        results = await asyncio.gather(
+            *[tasks[cmd] for cmd in tasks], return_exceptions=True
+        )
 
         data = {"multicommand": True}
-        for cmd in tasks:
-            try:
-                result = tasks[cmd].result()
+        for cmd, result in zip(tasks.keys(), results):
+            if not isinstance(result, (APIError, Exception)):
                 if result is None or result == {}:
                     result = {}
                 data[cmd] = result
-            except APIError:
-                pass
 
         return data
 


### PR DESCRIPTION
Multiple multicommand methods were double-awaiting tasks - first via asyncio.gather() with return_exceptions=True, then calling .result() on the same tasks. This caused ConnectionResetError and other exceptions when connections were lost.

Changed to properly use the results from gather() instead of calling .result() on completed tasks, preventing exceptions from being raised after they were already caught.

Fixed in:
- pyasic/rpc/base.py:144 - RPC _send_split_multicommand
- pyasic/web/espminer.py:79 - ESPMiner multicommand
- pyasic/web/auradine.py:149 - Auradine multicommand