### PR TITLE
fix: update RPC command for mining status retrieval in BOSMiner and BOSer

### DIFF
--- a/pyasic/miners/backends/braiins_os.py
+++ b/pyasic/miners/backends/braiins_os.py
@@ -93,7 +93,7 @@ BOSMINER_DATA_LOC = DataLocations(
         ),
         str(DataOptions.IS_MINING): DataFunction(
             "_is_mining",
-            [RPCAPICommand("rpc_devdetails", "devdetails")],
+            [RPCAPICommand("rpc_devs", "devs")],
         ),
         str(DataOptions.UPTIME): DataFunction(
             "_get_uptime",
@@ -588,18 +588,18 @@ class BOSMiner(BraiinsOSFirmware):
                 pass
         return None
 
-    async def _is_mining(self, rpc_devdetails: dict | None = None) -> bool | None:
-        if rpc_devdetails is None:
+    async def _is_mining(self, rpc_devs: dict | None = None) -> bool | None:
+        if rpc_devs is None:
             try:
-                rpc_devdetails = await self.rpc.send_command(
-                    "devdetails", ignore_errors=True, allow_warning=False
+                rpc_devs = await self.rpc.send_command(
+                    "devs", ignore_errors=True, allow_warning=False
                 )
             except APIError:
                 return None
 
-        if rpc_devdetails is not None:
+        if rpc_devs is not None:
             try:
-                return not rpc_devdetails["STATUS"][0]["Msg"] == "Unavailable"
+                return any(dev["MHS 5s"] > 0 for dev in rpc_devs["DEVS"])
             except LookupError:
                 pass
         return None
@@ -764,7 +764,7 @@ BOSER_DATA_LOC = DataLocations(
         ),
         str(DataOptions.IS_MINING): DataFunction(
             "_is_mining",
-            [RPCAPICommand("rpc_devdetails", "devdetails")],
+            [RPCAPICommand("rpc_devs", "devs")],
         ),
         str(DataOptions.UPTIME): DataFunction(
             "_get_uptime",
@@ -1125,18 +1125,18 @@ class BOSer(BraiinsOSFirmware):
                 pass
         return False
 
-    async def _is_mining(self, rpc_devdetails: dict | None = None) -> bool | None:
-        if rpc_devdetails is None:
+    async def _is_mining(self, rpc_devs: dict | None = None) -> bool | None:
+        if rpc_devs is None:
             try:
-                rpc_devdetails = await self.rpc.send_command(
-                    "devdetails", ignore_errors=True, allow_warning=False
+                rpc_devs = await self.rpc.send_command(
+                    "devs", ignore_errors=True, allow_warning=False
                 )
             except APIError:
                 return None
 
-        if rpc_devdetails is not None:
+        if rpc_devs is not None:
             try:
-                return not rpc_devdetails["STATUS"][0]["Msg"] == "Unavailable"
+                return any(dev["MHS 5s"] > 0 for dev in rpc_devs["DEVS"])
             except LookupError:
                 pass
         return None


### PR DESCRIPTION
This PR proposes a potential improvement to the `_is_mining` method in the miner classes. 
The main structure of the method is kept intact, but the command used to retrieve the mining status has been modified.

Previously, the method relied on reading the `Msg` field from the miner response, which did not reliably indicate whether mining was active. Another approach using the `Frequency` from `devdetails` was also found to be inaccurate, as miners in a paused/off state can report a frequency around 50 MHz for a long time, giving false positives.

In this proposal, the method now checks the `MHS 5s` value from the `devs` command to determine if any device is actively mining. While this seems to work better in my tests, there may be alternative commands or approaches that could achieve the same goal.

I would greatly appreciate feedback from maintainers and other contributors to determine the most robust way to detect active mining. It might also be worth exploring the use of `BOSerWebAPI.get_miner_details` for post-gRPC implementations to unify the approach across versions, as this method also returns, among other parameters, the actual mining status of the device.

Closes #328 