### PR TITLE
Fix VNish get_config for list-based autotune presets response is a list

### DIFF
--- a/pyasic/miners/backends/vnish.py
+++ b/pyasic/miners/backends/vnish.py
@@ -310,10 +310,13 @@ class VNish(VNishFirmware, BMMiner):
     async def get_config(self) -> MinerConfig:
         try:
             web_settings = await self.web.settings()
-            web_presets_dict = await self.web.autotune_presets()
-            web_presets = (
-                web_presets_dict.get("presets", []) if web_presets_dict else []
-            )
+            web_presets_response = await self.web.autotune_presets()
+            if isinstance(web_presets_response, dict):
+                web_presets = web_presets_response.get("presets", [])
+            elif isinstance(web_presets_response, list):
+                web_presets = web_presets_response
+            else:
+                web_presets = []
             web_perf_summary = (await self.web.perf_summary()) or {}
         except APIError:
             return self.config or MinerConfig()


### PR DESCRIPTION
## Summary
This fixes a VNish parsing issue where `get_config()` assumes `autotune_presets()` returns a dict and calls `.get("presets", [])`.

Some VNish miners return a list instead, which caused:
- `AttributeError: 'list' object has no attribute 'get'`
- wrapped as `APIError: Failed to call config ... while getting data`

## What changed
- Updated VNish config handling to support both response shapes:
  - dict response: use `response.get("presets", [])`
  - list response: use the list directly
  - unexpected type: fallback to empty list

## Why
This prevents `get_data()` from failing on miners that return list-based preset payloads, while preserving existing behavior for dict-based responses.

## Validation
- Reproduced failure on an S19j Pro running VNish v1.2.6 before the change.
- Re-ran data collection after the fix; `config` now loads successfully and `get_data()` completes, reutning a valid pyasic.data.MinerData object containing all expected data

## Compatibility
Backward compatible: existing dict-based VNish responses still behave the same.

## Human AI Review
This fix was created with Github Copilot and has been human reviewed (albeit by an amateur ;P )