### PR TITLE
fix: handle float and string values for BTMiner V3 fan speed

### DIFF
--- a/pyasic/miners/backends/btminer.py
+++ b/pyasic/miners/backends/btminer.py
@@ -1131,6 +1131,16 @@ class BTMinerV3(StockFirmware):
         if rpc_get_device_info is None:
             return []
         rpm = rpc_get_device_info.get("msg", {}).get("power", {}).get("fanspeed")
+        if rpm is None:
+            return []
+        
+        # Ensure rpm is an integer, as some models may return it as a string or float
+        if not isinstance(rpm, int):
+            try:
+                rpm = int(round(float(rpm)))
+            except (TypeError, ValueError):
+                return []
+
         return [Fan(speed=rpm)] if rpm is not None else []
 
     async def _get_serial_number(

--- a/pyasic/miners/backends/btminer.py
+++ b/pyasic/miners/backends/btminer.py
@@ -1133,7 +1133,7 @@ class BTMinerV3(StockFirmware):
         rpm = rpc_get_device_info.get("msg", {}).get("power", {}).get("fanspeed")
         if rpm is None:
             return []
-        
+
         # Ensure rpm is an integer, as some models may return it as a string or float
         if not isinstance(rpm, int):
             try:

--- a/tests/miners_tests/backends_tests/__init__.py
+++ b/tests/miners_tests/backends_tests/__init__.py
@@ -1,3 +1,4 @@
 from .avalonminer_tests import *
+from .btminer_tests import *
 from .elphapex_tests import *
 from .hammer_tests import *

--- a/tests/miners_tests/backends_tests/btminer_tests/__init__.py
+++ b/tests/miners_tests/backends_tests/btminer_tests/__init__.py
@@ -1,0 +1,1 @@
+from .test_v3_psu_fans import TestBTMinerV3PSUFans

--- a/tests/miners_tests/backends_tests/btminer_tests/test_v3_psu_fans.py
+++ b/tests/miners_tests/backends_tests/btminer_tests/test_v3_psu_fans.py
@@ -1,0 +1,46 @@
+"""Tests for BTMiner V3 PSU fan speed parsing."""
+
+import unittest
+
+from pyasic.miners.backends.btminer import BTMinerV3
+
+
+class TestBTMinerV3PSUFans(unittest.IsolatedAsyncioTestCase):
+    async def test_get_psu_fans_keeps_int_value(self):
+        miner = BTMinerV3("127.0.0.1")
+
+        fans = await miner._get_psu_fans(
+            rpc_get_device_info={"msg": {"power": {"fanspeed": 6000}}}
+        )
+
+        self.assertEqual(len(fans), 1)
+        self.assertEqual(fans[0].speed, 6000)
+
+    async def test_get_psu_fans_converts_float_value(self):
+        miner = BTMinerV3("127.0.0.1")
+
+        fans = await miner._get_psu_fans(
+            rpc_get_device_info={"msg": {"power": {"fanspeed": 26.1}}}
+        )
+
+        self.assertEqual(len(fans), 1)
+        self.assertEqual(fans[0].speed, 26)
+
+    async def test_get_psu_fans_converts_string_float_value(self):
+        miner = BTMinerV3("127.0.0.1")
+
+        fans = await miner._get_psu_fans(
+            rpc_get_device_info={"msg": {"power": {"fanspeed": "25.7"}}}
+        )
+
+        self.assertEqual(len(fans), 1)
+        self.assertEqual(fans[0].speed, 26)
+
+    async def test_get_psu_fans_invalid_value_returns_empty(self):
+        miner = BTMinerV3("127.0.0.1")
+
+        fans = await miner._get_psu_fans(
+            rpc_get_device_info={"msg": {"power": {"fanspeed": "n/a"}}}
+        )
+
+        self.assertEqual(fans, [])


### PR DESCRIPTION
I found that miner models M63S_VL59 and M63S_VK28 were not returning integers for their fan speed resulting in this error.

APIError: Failed to call fan_psu on M63S VL50 (Stock). 

This fix adds the ability to convert float and string values to integer values if the rpm is not already an integer.
The change also includes unit tests to cover this scenario for BTminers