### PR TITLE
stop 'btminer process is down err' from blocking get data process

### DIFF
--- a/pyasic/config/pools.py
+++ b/pyasic/config/pools.py
@@ -643,7 +643,7 @@ class PoolConfig(MinerConfigValue):
     def from_btminer_v3(cls, rpc_pools: dict) -> PoolConfig:
         try:
             pool_data = rpc_pools["pools"]
-        except KeyError:
+        except (KeyError, TypeError):
             return PoolConfig.default()
         pool_data = sorted(pool_data, key=lambda x: int(x["id"]))
 


### PR DESCRIPTION
Sometimes I found that btminers will return 'btminer process is down err' when getting pool config information, when this happens an exception is thrown but not handled, causing the entire get data process to fail and for nothing to be returned. I have added the TypeError exception type to the except statement to catch and handle the instance where rpc_pools["pools"] fails due to rpc_pools being the string 'btminer process is down err' in this scenario.