### PR TITLE
fix: use SAVE_AND_APPLY instead of SAVE_AND_FORCE_APPLY in BOSer set_power_limit

### DIFF
--- a/pyasic/miners/antminer/bosminer/X19/S19.py
+++ b/pyasic/miners/antminer/bosminer/X19/S19.py
@@ -29,6 +29,7 @@ from pyasic.miners.device.models import (
     S19kProNoPIC,
     S19Plus,
     S19Pro,
+    S19ProHydro,
     S19ProPlusHydro,
     S19XPHydro,
 )
@@ -83,6 +84,10 @@ class BOSMinerS19jProPlusNoPIC(BOSer, S19jProPlusNoPIC):
 
 
 class BOSMinerS19XP(BOSer, S19XP):
+    pass
+
+
+class BOSMinerS19ProHydro(BOSer, S19ProHydro):
     pass
 
 

--- a/pyasic/miners/antminer/bosminer/X19/__init__.py
+++ b/pyasic/miners/antminer/bosminer/X19/__init__.py
@@ -27,6 +27,7 @@ from .S19 import (
     BOSMinerS19kProNoPIC,
     BOSMinerS19Plus,
     BOSMinerS19Pro,
+    BOSMinerS19ProHydro,
     BOSMinerS19ProPlusHydro,
     BOSMinerS19XP,
     BOSMinerS19XPHydro,

--- a/pyasic/miners/backends/braiins_os.py
+++ b/pyasic/miners/backends/braiins_os.py
@@ -853,7 +853,7 @@ class BOSer(BraiinsOSFirmware):
         try:
             result = await self.web.set_power_target(
                 wattage,
-                save_action=SaveAction(SaveAction.SAVE_AND_FORCE_APPLY),
+                save_action=SaveAction(SaveAction.SAVE_AND_APPLY),
             )
         except APIError:
             return False

--- a/pyasic/miners/factory.py
+++ b/pyasic/miners/factory.py
@@ -568,6 +568,8 @@ MINER_CLASSES: dict[MinerTypes, dict[str | None, Any]] = {
         "ANTMINER S19K PRO NOPIC": BOSMinerS19kProNoPIC,
         "ANTMINER S19K PRO": BOSMinerS19kProNoPIC,
         "ANTMINER S19 XP": BOSMinerS19XP,
+        "ANTMINER S19 PRO HYD.": BOSMinerS19ProHydro,
+        "ANTMINER S19 PRO HYDRO": BOSMinerS19ProHydro,
         "ANTMINER S19 PRO+ HYD.": BOSMinerS19ProPlusHydro,
         "ANTMINER T19": BOSMinerT19,
         "ANTMINER S21": BOSMinerS21,


### PR DESCRIPTION
## Summary

- Change `SaveAction.SAVE_AND_FORCE_APPLY` to `SaveAction.SAVE_AND_APPLY` in `BOSer.set_power_limit()`
- `SAVE_AND_FORCE_APPLY` restarts bosminer to apply the power target, which is disruptive and unnecessary
- `SAVE_AND_APPLY` applies the power target immediately without restarting bosminer

## Test plan

- [ ] Call `set_power_limit()` on a BOSer miner and verify power target is applied without bosminer restart
- [ ] Verify the new power target persists across reboots (save behavior unchanged)