### PR TITLE
fix antminers with vnish firmware sometimes not bieng detected

### DIFF
--- a/pyasic/miners/backends/vnish.py
+++ b/pyasic/miners/backends/vnish.py
@@ -310,16 +310,22 @@ class VNish(VNishFirmware, BMMiner):
     async def get_config(self) -> MinerConfig:
         try:
             web_settings = await self.web.settings()
-            web_presets_dict = await self.web.autotune_presets()
-            web_presets = (
-                web_presets_dict.get("presets", []) if web_presets_dict else []
+            web_presets_response = await self.web.autotune_presets()
+            if isinstance(web_presets_response, dict):
+                web_presets = web_presets_response.get("presets", [])
+            elif isinstance(web_presets_response, list):
+                web_presets = web_presets_response
+            else:
+                web_presets = []
+            _perf_summary_raw = await self.web.perf_summary()
+            web_perf_summary = _perf_summary_raw if isinstance(_perf_summary_raw, dict) else {}
+            self.config = MinerConfig.from_vnish(
+                web_settings, web_presets, web_perf_summary
             )
-            web_perf_summary = (await self.web.perf_summary()) or {}
         except APIError:
             return self.config or MinerConfig()
-        self.config = MinerConfig.from_vnish(
-            web_settings, web_presets, web_perf_summary
-        )
+        except Exception as e:
+            return self.config or MinerConfig()
         return self.config
 
     async def set_power_limit(self, wattage: int) -> bool:

--- a/pyasic/miners/backends/vnish.py
+++ b/pyasic/miners/backends/vnish.py
@@ -318,13 +318,15 @@ class VNish(VNishFirmware, BMMiner):
             else:
                 web_presets = []
             _perf_summary_raw = await self.web.perf_summary()
-            web_perf_summary = _perf_summary_raw if isinstance(_perf_summary_raw, dict) else {}
+            web_perf_summary = (
+                _perf_summary_raw if isinstance(_perf_summary_raw, dict) else {}
+            )
             self.config = MinerConfig.from_vnish(
                 web_settings, web_presets, web_perf_summary
             )
         except APIError:
             return self.config or MinerConfig()
-        except Exception as e:
+        except Exception:
             return self.config or MinerConfig()
         return self.config
 

--- a/pyasic/miners/factory.py
+++ b/pyasic/miners/factory.py
@@ -936,7 +936,7 @@ class MinerFactory:
         return None
 
     async def _get_miner_socket(self, ip: str) -> MinerTypes | None:
-        commands = ["version", "devdetails"]
+        commands = ["version", "devdetails", "stats"]
         tasks = [asyncio.create_task(self._socket_ping(ip, cmd)) for cmd in commands]
 
         data = await concurrent_get_first_result(
@@ -1014,6 +1014,8 @@ class MinerFactory:
             return MinerTypes.MARATHON
         if "RWGLR" in upper_data:
             return MinerTypes.MSKMINER
+        if "VNISH" in upper_data:
+            return MinerTypes.VNISH
         if "ANTMINER" in upper_data and "DEVDETAILS" not in upper_data:
             return MinerTypes.ANTMINER
         if (
@@ -1028,8 +1030,6 @@ class MinerFactory:
             return MinerTypes.AVALONMINER
         if "GCMINER" in upper_data or "FLUXOS" in upper_data:
             return MinerTypes.AURADINE
-        if "VNISH" in upper_data:
-            return MinerTypes.VNISH
         return None
 
     async def send_web_command(


### PR DESCRIPTION
I found that some vnish antminers were not reporting data, specifically on version 1.3.0-alpha, the "version" command was not returning data, and "dev details" did not include vnish in the response, so we could not decipher that it was a vnish miner in get miner type. So, solve this ive added the "stats" command that does include vnish as well as moved the vnish check before the Antminer check, as the switch was picking up Antminer before vnish. This change also covers fixing autotune preset responses coming in different formats than expected.