### PR TITLE
Add Fluminer T3 support

### DIFF
--- a/docs/generate_miners.py
+++ b/docs/generate_miners.py
@@ -64,6 +64,8 @@ def backend_str(backend: MinerTypes) -> str:
             return "Stock Firmware Elphapex Miners"
         case MinerTypes.MSKMINER:
             return "MSKMiner Firmware Miners"
+        case MinerTypes.FLUMINER:
+            return "Stock Firmware Fluminer Miners"
     raise TypeError("Unknown miner backend, cannot generate docs")
 
 

--- a/docs/miners/fluminer/T.md
+++ b/docs/miners/fluminer/T.md
@@ -1,0 +1,16 @@
+# pyasic
+## T Models
+
+## T3 (Stock)
+
+- [ ] Shutdowns
+- [ ] Power Modes
+- [ ] Setpoints
+- [ ] Presets
+
+::: pyasic.miners.fluminer.native.T.T3.FluminerT3
+    handler: python
+    options:
+        show_root_heading: false
+        heading_level: 0
+

--- a/docs/miners/supported_types.md
+++ b/docs/miners/supported_types.md
@@ -1012,3 +1012,14 @@ details {
         </details>
     </ul>
 </details>
+<details>
+<summary>Stock Firmware Fluminer Miners:</summary>
+    <ul>
+        <details>
+            <summary>T Series:</summary>
+                <ul>
+                    <li><a href="../fluminer/T#t3-stock">T3 (Stock)</a></li>
+                </ul>
+        </details>
+    </ul>
+</details>

--- a/docs/settings/settings.md
+++ b/docs/settings/settings.md
@@ -22,6 +22,10 @@ Settings options:
 - `default_auradine_web_password`
 - `default_epic_web_password`
 - `default_hive_web_password`
+- `default_iceriver_web_password`
+- `default_elphapex_web_password`
+- `default_fluminer_web_password`
+- `default_mskminer_web_password`
 - `default_antminer_ssh_password`
 - `default_bosminer_ssh_password`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
         - Hammer DX: "miners/hammer/DX.md"
         - Iceriver KSX: "miners/iceriver/KSX.md"
         - Volcminer DX: "miners/volcminer/DX.md"
+        - Fluminer T: "miners/fluminer/T.md"
     - Base Miner: "miners/base_miner.md"
 - Settings:
       - Settings: "settings/settings.md"

--- a/pyasic/config/mining/__init__.py
+++ b/pyasic/config/mining/__init__.py
@@ -268,18 +268,15 @@ class MiningModePowerTune(MinerConfigValue):
         return cfg
 
     def as_boser(self) -> dict:
+        performance_power_target_kwargs: dict[str, Any] = {}
+        if self.power is not None:
+            performance_power_target_kwargs["power_target"] = Power(watt=self.power)
         cfg: dict[str, Any] = {
             "set_performance_mode": SetPerformanceModeRequest(
                 save_action=SaveAction(SaveAction.SAVE_AND_APPLY),
                 mode=PerformanceMode(
                     tuner_mode=TunerPerformanceMode(
-                        power_target=PowerTargetMode(
-                            power_target=(
-                                Power(watt=self.power)
-                                if self.power is not None
-                                else None
-                            )  # type: ignore[arg-type]
-                        )
+                        power_target=PowerTargetMode(**performance_power_target_kwargs)
                     )
                 ),
             ),
@@ -367,6 +364,11 @@ class MiningModeHashrateTune(MinerConfigValue):
         return {"autotuning": conf}
 
     def as_boser(self) -> dict:
+        performance_hashrate_target_kwargs: dict[str, Any] = {}
+        if self.hashrate is not None:
+            performance_hashrate_target_kwargs["terahash_per_second"] = float(
+                self.hashrate
+            )
         cfg: dict[str, Any] = {
             "set_performance_mode": SetPerformanceModeRequest(
                 save_action=SaveAction(SaveAction.SAVE_AND_APPLY),
@@ -374,11 +376,7 @@ class MiningModeHashrateTune(MinerConfigValue):
                     tuner_mode=TunerPerformanceMode(
                         hashrate_target=HashrateTargetMode(
                             hashrate_target=TeraHashrate(
-                                terahash_per_second=(
-                                    float(self.hashrate)
-                                    if self.hashrate is not None
-                                    else None
-                                )  # type: ignore[arg-type]
+                                **performance_hashrate_target_kwargs
                             )
                         )
                     )

--- a/pyasic/data/error_codes/__init__.py
+++ b/pyasic/data/error_codes/__init__.py
@@ -14,7 +14,7 @@
 #  limitations under the License.                                              -
 # ------------------------------------------------------------------------------
 
-from typing import TypeVar
+from typing import TypeAlias
 
 from .bos import BraiinsOSError
 from .innosilicon import InnosiliconError
@@ -22,11 +22,6 @@ from .vnish import VnishError
 from .whatsminer import WhatsminerError
 from .X19 import X19Error
 
-MinerErrorData = TypeVar(
-    "MinerErrorData",
-    WhatsminerError,
-    BraiinsOSError,
-    X19Error,
-    InnosiliconError,
-    VnishError,
+MinerErrorData: TypeAlias = (
+    WhatsminerError | BraiinsOSError | X19Error | InnosiliconError | VnishError
 )

--- a/pyasic/device/makes.py
+++ b/pyasic/device/makes.py
@@ -32,6 +32,7 @@ class MinerMake(str, Enum):
     VOLCMINER = "VolcMiner"
     ELPHAPEX = "Elphapex"
     BRAIINS = "Braiins"
+    FLUMINER = "Fluminer"
 
     def __str__(self):
         return self.value

--- a/pyasic/device/models.py
+++ b/pyasic/device/models.py
@@ -579,6 +579,13 @@ class ElphapexModels(MinerModelType):
         return self.value
 
 
+class FluminerModels(MinerModelType):
+    T3 = "T3"
+
+    def __str__(self):
+        return self.value
+
+
 class MinerModel:
     ANTMINER = AntminerModels
     WHATSMINER = WhatsminerModels
@@ -594,3 +601,4 @@ class MinerModel:
     VOLCMINER = VolcMinerModels
     ELPHAPEX = ElphapexModels
     BRAIINS = BraiinsModels
+    FLUMINER = FluminerModels

--- a/pyasic/miners/backends/__init__.py
+++ b/pyasic/miners/backends/__init__.py
@@ -24,6 +24,7 @@ from .btminer import BTMiner, BTMinerV2, BTMinerV3
 from .cgminer import CGMiner
 from .elphapex import ElphapexMiner
 from .epic import ePIC
+from .fluminer import Fluminer
 from .goldshell import GoldshellMiner
 from .hammer import BlackMiner
 from .hiveon import HiveonModern, HiveonOld

--- a/pyasic/miners/backends/btminer.py
+++ b/pyasic/miners/backends/btminer.py
@@ -926,7 +926,12 @@ class BTMinerV3(StockFirmware):
         except LookupError:
             pass
 
-        if pools is not None and settings is not None and device_info is not None:
+        if (
+            pools is not None
+            and settings is not None
+            and device_info is not None
+            and miner_summary is not None
+        ):
             self.config = MinerConfig.from_btminer_v3(
                 rpc_pools=pools,
                 rpc_settings=settings,
@@ -1166,7 +1171,10 @@ class BTMinerV3(StockFirmware):
                 except (TypeError, ValueError):
                     continue
 
-        return [WhatsminerError(error_code=code) for code in sorted(set(parsed_codes))]
+        errors: list[MinerErrorData] = [
+            WhatsminerError(error_code=code) for code in sorted(set(parsed_codes))
+        ]
+        return errors
 
     async def _get_serial_number(
         self, rpc_get_device_info: dict | None = None

--- a/pyasic/miners/backends/fluminer.py
+++ b/pyasic/miners/backends/fluminer.py
@@ -1,3 +1,5 @@
+"""Backend support for Fluminer stock firmware miners."""
+
 from pyasic import MinerConfig
 from pyasic.config.pools import Pool, PoolConfig, PoolGroup
 from pyasic.data import Fan, HashBoard
@@ -167,6 +169,8 @@ class Fluminer(StockFirmware):
     async def _get_uptime(self, web_summary: dict | None = None) -> int | None:
         summary = await self._get_summary(web_summary)
         uptime = summary.get("uptime")
+        if uptime is None:
+            return None
         try:
             return int(uptime)
         except (TypeError, ValueError):
@@ -264,6 +268,8 @@ class Fluminer(StockFirmware):
 
     @staticmethod
     def _float_or_none(value: object) -> float | None:
+        if not isinstance(value, (float, int, str)):
+            return None
         try:
             return float(value)
         except (TypeError, ValueError):
@@ -271,6 +277,8 @@ class Fluminer(StockFirmware):
 
     @staticmethod
     def _int_or_none(value: object) -> int | None:
+        if not isinstance(value, (float, int, str)):
+            return None
         try:
             return int(value)
         except (TypeError, ValueError):

--- a/pyasic/miners/backends/fluminer.py
+++ b/pyasic/miners/backends/fluminer.py
@@ -64,8 +64,6 @@ FLUMINER_DATA_LOC = DataLocations(
 
 
 class Fluminer(StockFirmware):
-    """Base handler for Fluminer stock firmware."""
-
     _web_cls = FluminerWebAPI
     web: FluminerWebAPI
 

--- a/pyasic/miners/backends/fluminer.py
+++ b/pyasic/miners/backends/fluminer.py
@@ -1,0 +1,306 @@
+from pyasic import MinerConfig
+from pyasic.config.pools import Pool, PoolConfig, PoolGroup
+from pyasic.data import Fan, HashBoard
+from pyasic.data.pools import PoolMetrics, PoolUrl
+from pyasic.device.algorithm import AlgoHashRateType
+from pyasic.errors import APIError
+from pyasic.miners.data import DataFunction, DataLocations, DataOptions, WebAPICommand
+from pyasic.miners.device.firmware import StockFirmware
+from pyasic.web.fluminer import FluminerWebAPI
+
+FLUMINER_DATA_LOC = DataLocations(
+    **{
+        str(DataOptions.SERIAL_NUMBER): DataFunction(
+            "_get_serial_number",
+            [WebAPICommand("web_overview", "api/overview")],
+        ),
+        str(DataOptions.MAC): DataFunction(
+            "_get_mac",
+            [WebAPICommand("web_overview", "api/overview")],
+        ),
+        str(DataOptions.FW_VERSION): DataFunction(
+            "_get_fw_ver",
+            [WebAPICommand("web_overview", "api/overview")],
+        ),
+        str(DataOptions.HOSTNAME): DataFunction(
+            "_get_hostname",
+            [WebAPICommand("web_overview", "api/overview")],
+        ),
+        str(DataOptions.HASHRATE): DataFunction(
+            "_get_hashrate",
+            [WebAPICommand("web_summary", "api/summary")],
+        ),
+        str(DataOptions.HASHBOARDS): DataFunction(
+            "_get_hashboards",
+            [WebAPICommand("web_summary", "api/summary")],
+        ),
+        str(DataOptions.WATTAGE): DataFunction(
+            "_get_wattage",
+            [WebAPICommand("web_summary", "api/summary")],
+        ),
+        str(DataOptions.FANS): DataFunction(
+            "_get_fans",
+            [WebAPICommand("web_summary", "api/summary")],
+        ),
+        str(DataOptions.IS_MINING): DataFunction(
+            "_is_mining",
+            [WebAPICommand("web_summary", "api/summary")],
+        ),
+        str(DataOptions.UPTIME): DataFunction(
+            "_get_uptime",
+            [WebAPICommand("web_summary", "api/summary")],
+        ),
+        str(DataOptions.POOLS): DataFunction(
+            "_get_pools",
+            [
+                WebAPICommand("web_summary", "api/summary"),
+                WebAPICommand("web_pools", "api/getPools"),
+            ],
+        ),
+    }
+)
+
+
+class Fluminer(StockFirmware):
+    """Base handler for Fluminer stock firmware."""
+
+    _web_cls = FluminerWebAPI
+    web: FluminerWebAPI
+
+    data_locations = FLUMINER_DATA_LOC
+
+    async def get_config(self) -> MinerConfig:
+        try:
+            web_pools = await self.web.pools()
+        except APIError:
+            return MinerConfig()
+
+        pools = []
+        for pool in self._get_configured_pools(web_pools):
+            if pool.get("url"):
+                pools.append(
+                    Pool(
+                        url=pool["url"],
+                        user=pool.get("user", ""),
+                        password=pool.get("pass", ""),
+                    )
+                )
+        return MinerConfig(pools=PoolConfig(groups=[PoolGroup(pools=pools)]))
+
+    async def _get_serial_number(self, web_overview: dict | None = None) -> str | None:
+        miner_info = await self._get_miner_info(web_overview)
+        return miner_info.get("sn") or None
+
+    async def _get_mac(self, web_overview: dict | None = None) -> str | None:
+        miner_info = await self._get_miner_info(web_overview)
+        mac = miner_info.get("macAddress") or miner_info.get("wifiMacAddress")
+        if isinstance(mac, str) and mac:
+            return mac.upper()
+        return None
+
+    async def _get_fw_ver(self, web_overview: dict | None = None) -> str | None:
+        miner_info = await self._get_miner_info(web_overview)
+        return miner_info.get("minerVersion") or None
+
+    async def _get_hostname(self, web_overview: dict | None = None) -> str | None:
+        miner_info = await self._get_miner_info(web_overview)
+        sn = miner_info.get("sn")
+        if sn:
+            return f"fluminer-{sn}"
+        return None
+
+    async def _get_hashrate(
+        self, web_summary: dict | None = None
+    ) -> AlgoHashRateType | None:
+        summary = await self._get_summary(web_summary)
+        return self._hashrate_from_gh(summary.get("hrt"))
+
+    async def _get_hashboards(self, web_summary: dict | None = None) -> list[HashBoard]:
+        if self.expected_hashboards is None:
+            return []
+
+        hashboards = [
+            HashBoard(slot=i, expected_chips=self.expected_chips)
+            for i in range(self.expected_hashboards)
+        ]
+        summary = await self._get_summary(web_summary)
+        if not summary:
+            return hashboards
+
+        hashrate = self._hashrate_from_gh(summary.get("hrt"))
+        temps = self._split_ints(summary.get("temp"))
+
+        hashboards[0].hashrate = hashrate
+        hashboards[0].temp = temps[0] if len(temps) > 0 else None
+        hashboards[0].chip_temp = temps[1] if len(temps) > 1 else None
+        hashboards[0].missing = False
+        hashboards[0].active = summary.get("status") == "OK"
+        hashboards[0].voltage = self._float_or_none(summary.get("voltage"))
+        return hashboards
+
+    async def _get_wattage(self, web_summary: dict | None = None) -> int | None:
+        summary = await self._get_summary(web_summary)
+        wattage = self._float_or_none(summary.get("power"))
+        return round(wattage) if wattage is not None else None
+
+    async def _get_voltage(self, web_summary: dict | None = None) -> float | None:
+        summary = await self._get_summary(web_summary)
+        return self._float_or_none(summary.get("voltage"))
+
+    async def _get_fans(self, web_summary: dict | None = None) -> list[Fan]:
+        summary = await self._get_summary(web_summary)
+        speeds = self._split_ints(summary.get("fan"))
+        if self.expected_fans is not None:
+            speeds = speeds[: self.expected_fans]
+            return [
+                Fan(speed=speeds[i]) if i < len(speeds) else Fan()
+                for i in range(self.expected_fans)
+            ]
+        return [Fan(speed=speed) for speed in speeds]
+
+    async def _is_mining(self, web_summary: dict | None = None) -> bool | None:
+        summary = await self._get_summary(web_summary)
+        return summary.get("status") == "OK" and self._float_or_none(
+            summary.get("hrt")
+        ) not in (None, 0.0)
+
+    async def _get_uptime(self, web_summary: dict | None = None) -> int | None:
+        summary = await self._get_summary(web_summary)
+        uptime = summary.get("uptime")
+        try:
+            return int(uptime)
+        except (TypeError, ValueError):
+            return None
+
+    async def _get_pools(
+        self,
+        web_summary: dict | None = None,
+        web_pools: dict | None = None,
+    ) -> list[PoolMetrics]:
+        summary = await self._get_summary(web_summary)
+        if web_pools is None:
+            try:
+                web_pools = await self.web.pools()
+            except APIError:
+                web_pools = None
+
+        pools = []
+        configured_pools = self._get_configured_pools(web_pools)
+        for idx, pool in enumerate(configured_pools):
+            url = pool.get("url")
+            if not url:
+                continue
+            pool_url = self._pool_url_from_str(url)
+            if pool_url is None:
+                continue
+            active = self._is_active_pool(summary, url)
+            pools.append(
+                PoolMetrics(
+                    accepted=self._int_or_none(summary.get("acc")) if active else None,
+                    rejected=self._int_or_none(summary.get("rej")) if active else None,
+                    active=active,
+                    alive=summary.get("poolAlive") == "1" if active else None,
+                    url=pool_url,
+                    user=pool.get("user"),
+                    index=idx,
+                )
+            )
+        return pools
+
+    async def _get_miner_info(self, web_overview: dict | None = None) -> dict:
+        if web_overview is None:
+            try:
+                web_overview = await self.web.overview()
+            except APIError:
+                return {}
+        data = web_overview.get("data") if isinstance(web_overview, dict) else None
+        if not isinstance(data, dict):
+            return {}
+        miner_info = data.get("minerInfo")
+        if isinstance(miner_info, dict):
+            return miner_info
+        return {}
+
+    async def _get_summary(self, web_summary: dict | None = None) -> dict:
+        if web_summary is None:
+            try:
+                web_summary = await self.web.summary()
+            except APIError:
+                return {}
+        data = web_summary.get("data") if isinstance(web_summary, dict) else None
+        if not isinstance(data, dict):
+            return {}
+        summaries = data.get("summary")
+        if (
+            isinstance(summaries, list)
+            and len(summaries) > 0
+            and isinstance(summaries[0], dict)
+        ):
+            return summaries[0]
+        return {}
+
+    def _hashrate_from_gh(self, value: object) -> AlgoHashRateType | None:
+        hashrate = self._float_or_none(value)
+        if hashrate is None:
+            return None
+        return self.algo.hashrate(
+            rate=hashrate,
+            unit=self.algo.unit.GH,  # type: ignore[attr-defined]
+        ).into(
+            self.algo.unit.default  # type: ignore[attr-defined]
+        )
+
+    @staticmethod
+    def _split_ints(value: object) -> list[int]:
+        if not isinstance(value, str):
+            return []
+        values = []
+        for item in value.split("|"):
+            try:
+                values.append(round(float(item)))
+            except ValueError:
+                continue
+        return values
+
+    @staticmethod
+    def _float_or_none(value: object) -> float | None:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _int_or_none(value: object) -> int | None:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _get_configured_pools(web_pools: dict | None) -> list[dict]:
+        data = web_pools.get("data") if isinstance(web_pools, dict) else None
+        if not isinstance(data, dict):
+            return []
+        pools = data.get("pools")
+        if not isinstance(pools, list):
+            return []
+        return [pool for pool in pools if isinstance(pool, dict)]
+
+    @staticmethod
+    def _pool_url_from_str(url: str) -> PoolUrl | None:
+        try:
+            return PoolUrl.from_str(url)
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def _is_active_pool(cls, summary: dict, url: str) -> bool:
+        pool_host = summary.get("pool")
+        pool_port = summary.get("port")
+        pool_url = cls._pool_url_from_str(url)
+        return (
+            pool_url is not None
+            and isinstance(pool_host, str)
+            and pool_url.host == pool_host
+            and (pool_port is None or str(pool_url.port) == str(pool_port))
+        )

--- a/pyasic/miners/device/makes.py
+++ b/pyasic/miners/device/makes.py
@@ -72,3 +72,7 @@ class BraiinsMake(BaseMiner):
 
 class ElphapexMake(BaseMiner):
     make = MinerMake.ELPHAPEX
+
+
+class FluminerMake(BaseMiner):
+    make = MinerMake.FLUMINER

--- a/pyasic/miners/device/models/__init__.py
+++ b/pyasic/miners/device/models/__init__.py
@@ -20,6 +20,7 @@ from .avalonminer import *
 from .braiins import *
 from .elphapex import *
 from .epic import *
+from .fluminer import *
 from .goldshell import *
 from .hammer import *
 from .iceriver import *

--- a/pyasic/miners/device/models/fluminer/T/T3.py
+++ b/pyasic/miners/device/models/fluminer/T/T3.py
@@ -1,0 +1,12 @@
+from pyasic.device.algorithm import MinerAlgo
+from pyasic.device.models import MinerModel
+from pyasic.miners.device.makes import FluminerMake
+
+
+class T3(FluminerMake):
+    raw_model = MinerModel.FLUMINER.T3
+
+    expected_hashboards = 1
+    expected_chips = 96
+    expected_fans = 4
+    algo = MinerAlgo.SHA256

--- a/pyasic/miners/device/models/fluminer/T/T3.py
+++ b/pyasic/miners/device/models/fluminer/T/T3.py
@@ -6,8 +6,6 @@ from pyasic.miners.device.makes import FluminerMake
 
 
 class T3(FluminerMake):
-    """Fluminer T3 static model metadata."""
-
     raw_model = MinerModel.FLUMINER.T3
 
     expected_hashboards = 1

--- a/pyasic/miners/device/models/fluminer/T/T3.py
+++ b/pyasic/miners/device/models/fluminer/T/T3.py
@@ -1,9 +1,13 @@
+"""Fluminer T3 model metadata."""
+
 from pyasic.device.algorithm import MinerAlgo
 from pyasic.device.models import MinerModel
 from pyasic.miners.device.makes import FluminerMake
 
 
 class T3(FluminerMake):
+    """Fluminer T3 static model metadata."""
+
     raw_model = MinerModel.FLUMINER.T3
 
     expected_hashboards = 1

--- a/pyasic/miners/device/models/fluminer/T/__init__.py
+++ b/pyasic/miners/device/models/fluminer/T/__init__.py
@@ -1,1 +1,3 @@
+"""Fluminer T-series model metadata."""
+
 from .T3 import T3

--- a/pyasic/miners/device/models/fluminer/T/__init__.py
+++ b/pyasic/miners/device/models/fluminer/T/__init__.py
@@ -1,0 +1,1 @@
+from .T3 import T3

--- a/pyasic/miners/device/models/fluminer/__init__.py
+++ b/pyasic/miners/device/models/fluminer/__init__.py
@@ -1,0 +1,1 @@
+from .T import *

--- a/pyasic/miners/device/models/fluminer/__init__.py
+++ b/pyasic/miners/device/models/fluminer/__init__.py
@@ -1,1 +1,3 @@
+"""Fluminer model metadata."""
+
 from .T import *

--- a/pyasic/miners/factory.py
+++ b/pyasic/miners/factory.py
@@ -857,8 +857,9 @@ class MinerFactory:
 
             text, resp = await concurrent_get_first_result(
                 tasks,
-                lambda x: x[0] is not None
-                and self._parse_web_type(x[0], x[1]) is not None,
+                lambda x: (
+                    x[0] is not None and self._parse_web_type(x[0], x[1]) is not None
+                ),
             )
             if text is not None:
                 mtype = self._parse_web_type(text, resp)

--- a/pyasic/miners/factory.py
+++ b/pyasic/miners/factory.py
@@ -39,6 +39,7 @@ from pyasic.miners.blockminer import *
 from pyasic.miners.braiins import *
 from pyasic.miners.device.makes import *
 from pyasic.miners.elphapex import *
+from pyasic.miners.fluminer import *
 from pyasic.miners.goldshell import *
 from pyasic.miners.hammer import *
 from pyasic.miners.iceriver import *
@@ -69,6 +70,7 @@ class MinerTypes(enum.Enum):
     LUCKYMINER = 16
     ELPHAPEX = 17
     MSKMINER = 18
+    FLUMINER = 19
 
 
 MINER_CLASSES: dict[MinerTypes, dict[str | None, Any]] = {
@@ -717,6 +719,10 @@ MINER_CLASSES: dict[MinerTypes, dict[str | None, Any]] = {
         "DG1": ElphapexDG1,
         "DG1-Home": ElphapexDG1Home,
     },
+    MinerTypes.FLUMINER: {
+        None: type("FluminerUnknown", (Fluminer, FluminerMake), {}),
+        "T3": FluminerT3,
+    },
 }
 
 
@@ -802,6 +808,7 @@ class MinerFactory:
                 MinerTypes.HAMMER: self.get_miner_model_hammer,
                 MinerTypes.VOLCMINER: self.get_miner_model_volcminer,
                 MinerTypes.ELPHAPEX: self.get_miner_model_elphapex,
+                MinerTypes.FLUMINER: self.get_miner_model_fluminer,
             }
             version: str | None = None
             miner_version_fns = {
@@ -930,6 +937,8 @@ class MinerFactory:
             return MinerTypes.AVALONMINER
         if "DragonMint" in web_text:
             return MinerTypes.INNOSILICON
+        if "<title>Fluminer</title>" in web_text or "Fluminer" in web_text:
+            return MinerTypes.FLUMINER
         if "Miner UI" in web_text:
             return MinerTypes.AURADINE
         return None
@@ -1573,6 +1582,16 @@ class MinerFactory:
             try:
                 miner_model = web_json_data["minertype"]
                 return miner_model
+            except (TypeError, LookupError):
+                pass
+        return None
+
+    async def get_miner_model_fluminer(self, ip: str) -> str | None:
+        web_json_data = await self.send_web_command(ip, "/api/overview")
+
+        if web_json_data is not None:
+            try:
+                return web_json_data["data"]["minerInfo"]["model"]
             except (TypeError, LookupError):
                 pass
         return None

--- a/pyasic/miners/fluminer/__init__.py
+++ b/pyasic/miners/fluminer/__init__.py
@@ -1,0 +1,1 @@
+from .native import *

--- a/pyasic/miners/fluminer/__init__.py
+++ b/pyasic/miners/fluminer/__init__.py
@@ -1,1 +1,3 @@
+"""Fluminer miner classes."""
+
 from .native import *

--- a/pyasic/miners/fluminer/native/T/T3.py
+++ b/pyasic/miners/fluminer/native/T/T3.py
@@ -1,0 +1,6 @@
+from pyasic.miners.backends.fluminer import Fluminer
+from pyasic.miners.device.models.fluminer import T3
+
+
+class FluminerT3(Fluminer, T3):
+    pass

--- a/pyasic/miners/fluminer/native/T/T3.py
+++ b/pyasic/miners/fluminer/native/T/T3.py
@@ -1,6 +1,10 @@
+"""Fluminer T3 native firmware miner class."""
+
 from pyasic.miners.backends.fluminer import Fluminer
 from pyasic.miners.device.models.fluminer import T3
 
 
 class FluminerT3(Fluminer, T3):
+    """Fluminer T3 running native stock firmware."""
+
     pass

--- a/pyasic/miners/fluminer/native/T/T3.py
+++ b/pyasic/miners/fluminer/native/T/T3.py
@@ -5,6 +5,4 @@ from pyasic.miners.device.models.fluminer import T3
 
 
 class FluminerT3(Fluminer, T3):
-    """Fluminer T3 running native stock firmware."""
-
     pass

--- a/pyasic/miners/fluminer/native/T/__init__.py
+++ b/pyasic/miners/fluminer/native/T/__init__.py
@@ -1,1 +1,3 @@
+"""Fluminer T-series native firmware miner classes."""
+
 from .T3 import FluminerT3

--- a/pyasic/miners/fluminer/native/T/__init__.py
+++ b/pyasic/miners/fluminer/native/T/__init__.py
@@ -1,0 +1,1 @@
+from .T3 import FluminerT3

--- a/pyasic/miners/fluminer/native/__init__.py
+++ b/pyasic/miners/fluminer/native/__init__.py
@@ -1,0 +1,1 @@
+from .T import *

--- a/pyasic/miners/fluminer/native/__init__.py
+++ b/pyasic/miners/fluminer/native/__init__.py
@@ -1,1 +1,3 @@
+"""Fluminer native firmware miner classes."""
+
 from .T import *

--- a/pyasic/settings/__init__.py
+++ b/pyasic/settings/__init__.py
@@ -43,6 +43,7 @@ class Settings(BaseModel):
     default_hive_web_password: str = Field(default="root")
     default_iceriver_web_password: str = Field(default="12345678")
     default_elphapex_web_password: str = Field(default="root")
+    default_fluminer_web_password: str = Field(default="root")
     default_mskminer_web_password: str = Field(default="root")
     default_antminer_ssh_password: str = Field(default="miner")
     default_bosminer_ssh_password: str = Field(default="root")

--- a/pyasic/web/__init__.py
+++ b/pyasic/web/__init__.py
@@ -18,6 +18,7 @@ from .auradine import AuradineWebAPI
 from .base import BaseWebAPI
 from .braiins_os import BOSerWebAPI, BOSMinerWebAPI
 from .epic import ePICWebAPI
+from .fluminer import FluminerWebAPI
 from .goldshell import GoldshellWebAPI
 from .hammer import HammerWebAPI
 from .iceriver import IceRiverWebAPI

--- a/pyasic/web/fluminer.py
+++ b/pyasic/web/fluminer.py
@@ -15,9 +15,8 @@ from pyasic.web.base import BaseWebAPI
 
 
 class FluminerWebAPI(BaseWebAPI):
-    """Read-oriented client for Fluminer native web API endpoints."""
-
     def __init__(self, ip: str) -> None:
+        """Initialize the web API client and parse optional host ports."""
         super().__init__(ip)
         parsed = urlsplit(f"//{ip}")
         if parsed.hostname is not None:

--- a/pyasic/web/fluminer.py
+++ b/pyasic/web/fluminer.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+
+from pyasic import settings
+from pyasic.errors import APIError
+from pyasic.web.base import BaseWebAPI
+
+
+class FluminerWebAPI(BaseWebAPI):
+    def __init__(self, ip: str) -> None:
+        super().__init__(ip)
+        parsed = urlsplit(f"//{ip}")
+        if parsed.hostname is not None:
+            self.ip = parsed.hostname
+        if parsed.port is not None:
+            self.port = parsed.port
+        self.username = "root"
+        self.pwd = settings.get("default_fluminer_web_password", "root")
+        self._session_cookie: str | None = None
+
+    async def auth(self) -> str | None:
+        async with httpx.AsyncClient(transport=settings.transport()) as client:
+            try:
+                response = await client.post(
+                    f"http://{self.ip}:{self.port}/api/login",
+                    json={"username": self.username, "password": self.pwd},
+                    timeout=settings.get("api_function_timeout", 5),
+                )
+                data = response.json()
+            except (httpx.HTTPError, json.JSONDecodeError):
+                return None
+
+            if data.get("code") != 0:
+                return None
+
+            session_cookie = response.cookies.get("session")
+            self._session_cookie = session_cookie
+            return session_cookie
+
+    async def send_command(
+        self,
+        command: str,
+        ignore_errors: bool = False,
+        allow_warning: bool = True,
+        privileged: bool = False,
+        **parameters: Any,
+    ) -> dict:
+        command = command.lstrip("/")
+        url = f"http://{self.ip}:{self.port}/{command}"
+
+        async with httpx.AsyncClient(transport=settings.transport()) as client:
+            retries = settings.get("get_data_retries", 1)
+            if privileged:
+                retries = max(retries, 2)
+            for attempt in range(retries):
+                if privileged and self._session_cookie is None:
+                    await self.auth()
+                try:
+                    response = await client.get(
+                        url,
+                        cookies=(
+                            {"session": self._session_cookie}
+                            if self._session_cookie is not None
+                            else None
+                        ),
+                        timeout=settings.get("api_function_timeout", 5),
+                    )
+                    data = response.json()
+                except (httpx.HTTPError, json.JSONDecodeError):
+                    if attempt == retries - 1 and not ignore_errors:
+                        raise APIError(f"Failed to send command to miner API: {url}")
+                    continue
+
+                if data.get("code") == 401 and privileged and attempt < retries - 1:
+                    self._session_cookie = None
+                    await self.auth()
+                    continue
+                if response.status_code == 200 and data.get("code") == 0:
+                    return data
+                if ignore_errors:
+                    return data
+
+        raise APIError(f"Command failed: {command}")
+
+    async def multicommand(
+        self, *commands: str, ignore_errors: bool = False, allow_warning: bool = True
+    ) -> dict:
+        tasks = {
+            command: asyncio.create_task(
+                self.send_command(
+                    command,
+                    ignore_errors=ignore_errors,
+                    allow_warning=allow_warning,
+                    privileged=command == "api/getPools",
+                )
+            )
+            for command in commands
+        }
+        results = await asyncio.gather(*tasks.values(), return_exceptions=True)
+
+        data: dict[str, Any] = {"multicommand": True}
+        for command, result in zip(tasks.keys(), results):
+            if isinstance(result, dict):
+                data[command] = result
+        return data
+
+    async def overview(self) -> dict:
+        return await self.send_command("api/overview")
+
+    async def summary(self) -> dict:
+        return await self.send_command("api/summary")
+
+    async def network(self) -> dict:
+        return await self.send_command("api/getNetwork")
+
+    async def pools(self) -> dict:
+        return await self.send_command("api/getPools", privileged=True)

--- a/pyasic/web/fluminer.py
+++ b/pyasic/web/fluminer.py
@@ -1,3 +1,5 @@
+"""Web API client for Fluminer stock firmware."""
+
 from __future__ import annotations
 
 import asyncio
@@ -13,6 +15,8 @@ from pyasic.web.base import BaseWebAPI
 
 
 class FluminerWebAPI(BaseWebAPI):
+    """Read-oriented client for Fluminer native web API endpoints."""
+
     def __init__(self, ip: str) -> None:
         super().__init__(ip)
         parsed = urlsplit(f"//{ip}")
@@ -25,6 +29,7 @@ class FluminerWebAPI(BaseWebAPI):
         self._session_cookie: str | None = None
 
     async def auth(self) -> str | None:
+        """Authenticate with the web UI and cache the session cookie."""
         async with httpx.AsyncClient(transport=settings.transport()) as client:
             try:
                 response = await client.post(
@@ -111,13 +116,17 @@ class FluminerWebAPI(BaseWebAPI):
         return data
 
     async def overview(self) -> dict:
+        """Return miner overview and identity information."""
         return await self.send_command("api/overview")
 
     async def summary(self) -> dict:
+        """Return current mining summary information."""
         return await self.send_command("api/summary")
 
     async def network(self) -> dict:
+        """Return current network configuration information."""
         return await self.send_command("api/getNetwork")
 
     async def pools(self) -> dict:
+        """Return configured pool information."""
         return await self.send_command("api/getPools", privileged=True)

--- a/tests/local_tests/test_fluminer_local.py
+++ b/tests/local_tests/test_fluminer_local.py
@@ -1,0 +1,114 @@
+import argparse
+import os
+import sys
+import unittest
+
+from pyasic.miners.base import BaseMiner
+from pyasic.miners.data import DataOptions
+from pyasic.miners.factory import MinerFactory
+from pyasic.miners.fluminer import FluminerT3
+from pyasic.web.fluminer import FluminerWebAPI
+
+
+class TestFluminerLocal(unittest.IsolatedAsyncioTestCase):
+    ip: str | None = None
+    miner: BaseMiner
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.ip = os.getenv("FLUMINER_IP")
+        if not cls.ip:
+            raise unittest.SkipTest("Set FLUMINER_IP to run local Fluminer tests")
+
+    async def asyncSetUp(self) -> None:
+        if self.ip is None:
+            self.skipTest("Set FLUMINER_IP to run local Fluminer tests")
+        factory = MinerFactory()
+        miner = await factory.get_miner(self.ip)  # type: ignore[func-returns-value]
+        if miner is None:
+            self.skipTest("Miner discovery failed; check IP")
+        self.miner = miner
+        return None
+
+    async def test_discovery_detects_fluminer_t3(self) -> None:
+        self.assertIsInstance(self.miner, FluminerT3)
+
+    async def test_get_data_basics(self) -> None:
+        data = await self.miner.get_data(
+            include=[
+                DataOptions.SERIAL_NUMBER,
+                DataOptions.FW_VERSION,
+                DataOptions.HASHRATE,
+                DataOptions.WATTAGE,
+                DataOptions.FANS,
+                DataOptions.HASHBOARDS,
+                DataOptions.POOLS,
+                DataOptions.IS_MINING,
+            ]
+        )
+
+        if data.serial_number is None:
+            self.skipTest("Serial number not reported; skipping")
+        if data.fw_ver is None:
+            self.skipTest("FW version not reported; skipping")
+        if data.hashrate is None:
+            self.skipTest("Hashrate not reported; skipping")
+        if data.wattage is None:
+            self.skipTest("Wattage not reported; skipping")
+        if data.is_mining is None:
+            self.skipTest("Mining status not reported; skipping")
+        if data.fans is None or len(data.fans) == 0:
+            self.skipTest("Fans not reported; skipping")
+        if data.hashboards is None or len(data.hashboards) == 0:
+            self.skipTest("Hashboards not reported; skipping")
+        if data.pools is None or len(data.pools) == 0:
+            self.skipTest("Pools not reported; skipping")
+
+        self.assertEqual(type(self.miner).__name__, "FluminerT3")
+        self.assertEqual(data.model, "T3")
+        self.assertIsNotNone(data.serial_number)
+        self.assertIsNotNone(data.fw_ver)
+        self.assertIsNotNone(data.hashrate)
+        self.assertIsNotNone(data.wattage)
+        self.assertIsNotNone(data.is_mining)
+        self.assertEqual(len(data.fans), 4)
+        self.assertEqual(len(data.hashboards), 1)
+        self.assertEqual(data.hashboards[0].expected_chips, 96)
+        self.assertIsNone(data.hashboards[0].chips)
+        self.assertGreaterEqual(len(data.pools), 1)
+
+    async def test_get_config_returns_configured_pools(self) -> None:
+        cfg = await self.miner.get_config()
+        self.assertGreaterEqual(len(cfg.pools.groups), 1)
+        self.assertGreaterEqual(len(cfg.pools.groups[0].pools), 1)
+
+    async def test_native_web_api_read_only_endpoints(self) -> None:
+        web = getattr(self.miner, "web", None)
+        if web is None or not isinstance(web, FluminerWebAPI):
+            self.skipTest("No Fluminer web client available")
+
+        overview = await web.overview()
+        summary = await web.summary()
+        pools = await web.pools()
+
+        self.assertEqual(overview.get("code"), 0)
+        self.assertEqual(summary.get("code"), 0)
+        self.assertEqual(pools.get("code"), 0)
+        self.assertIn("minerInfo", overview.get("data", {}))
+        self.assertIn("summary", summary.get("data", {}))
+        self.assertIn("pools", pools.get("data", {}))
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(description="Local Fluminer T3 smoke tests")
+    parser.add_argument("ip", nargs="?", help="Miner IP (overrides FLUMINER_IP)")
+    args, unittest_args = parser.parse_known_args()
+
+    if args.ip:
+        os.environ["FLUMINER_IP"] = args.ip
+
+    unittest.main(argv=[sys.argv[0]] + unittest_args)
+
+
+if __name__ == "__main__":
+    _main()

--- a/tests/miners_tests/backends_tests/__init__.py
+++ b/tests/miners_tests/backends_tests/__init__.py
@@ -1,3 +1,4 @@
 from .avalonminer_tests import *
 from .elphapex_tests import *
+from .fluminer_tests import *
 from .hammer_tests import *

--- a/tests/miners_tests/backends_tests/fluminer_tests.py
+++ b/tests/miners_tests/backends_tests/fluminer_tests.py
@@ -1,3 +1,5 @@
+"""Tests for Fluminer stock firmware backend data handling."""
+
 import unittest
 
 from pyasic.miners.backends.fluminer import Fluminer
@@ -59,10 +61,13 @@ POOLS = {
 
 
 class TestFluminer(unittest.IsolatedAsyncioTestCase):
+    """Tests for Fluminer T3 data parsing and factory detection."""
+
     def setUp(self):
         self.miner = FluminerT3("127.0.0.1")
 
     async def test_summary_data(self):
+        """Fluminer summary payloads map into standard pyasic data."""
         self.assertEqual(
             await self.miner._get_serial_number(OVERVIEW),
             OVERVIEW["data"]["minerInfo"]["sn"],
@@ -77,6 +82,7 @@ class TestFluminer(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(await self.miner._is_mining(SUMMARY))
 
     async def test_fans_and_hashboards(self):
+        """Fan and hashboard data are parsed from the summary payload."""
         fans = await self.miner._get_fans(SUMMARY)
         self.assertEqual([fan.speed for fan in fans], [3524, 3583, 3583, 3613])
 
@@ -90,6 +96,7 @@ class TestFluminer(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(hashboards[0].voltage, 26.38)
 
     async def test_empty_summary_preserves_expected_hashboard_placeholder(self):
+        """Missing summary data keeps expected hashboard placeholders."""
         hashboards = await self.miner._get_hashboards({"code": 0, "data": {}})
 
         self.assertEqual(len(hashboards), 1)
@@ -97,6 +104,7 @@ class TestFluminer(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(hashboards[0].hashrate)
 
     async def test_partial_fan_data_preserves_expected_fan_count(self):
+        """Partial fan payloads preserve the static expected fan count."""
         summary = {
             **SUMMARY,
             "data": {
@@ -110,6 +118,7 @@ class TestFluminer(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([fan.speed for fan in fans], [3524, 3583, None, None])
 
     async def test_pools(self):
+        """Configured pools map to pool metrics with active pool share counts."""
         pools = await self.miner._get_pools(web_summary=SUMMARY, web_pools=POOLS)
 
         self.assertEqual(len(pools), 2)
@@ -121,6 +130,7 @@ class TestFluminer(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(pools[1].accepted)
 
     async def test_active_pool_matching_requires_exact_host_and_port(self):
+        """Active pool detection requires exact URL host and port matches."""
         pools = await self.miner._get_pools(
             web_summary=SUMMARY,
             web_pools={
@@ -150,6 +160,7 @@ class TestFluminer(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([pool.active for pool in pools], [False, False, True])
 
     async def test_malformed_payloads_return_empty_data(self):
+        """Malformed nested payload values return empty data instead of raising."""
         self.assertIsNone(
             await self.miner._get_serial_number({"code": 0, "data": None})
         )
@@ -174,11 +185,13 @@ class TestFluminer(unittest.IsolatedAsyncioTestCase):
         )
 
     async def test_unknown_fluminer_has_no_expected_hashboards(self):
+        """Unknown Fluminer models do not invent expected hashboards."""
         miner = Fluminer("127.0.0.1")
 
         self.assertEqual(await miner._get_hashboards(SUMMARY), [])
 
     def test_factory_detects_fluminer_before_generic_miner_ui(self):
+        """Factory parsing prefers Fluminer branding over generic UI text."""
         self.assertEqual(
             MinerFactory._parse_web_type(
                 "<html><title>Fluminer</title>Miner UI</html>",

--- a/tests/miners_tests/backends_tests/fluminer_tests.py
+++ b/tests/miners_tests/backends_tests/fluminer_tests.py
@@ -1,0 +1,190 @@
+import unittest
+
+from pyasic.miners.backends.fluminer import Fluminer
+from pyasic.miners.factory import MinerFactory, MinerTypes
+from pyasic.miners.fluminer import FluminerT3
+
+OVERVIEW = {
+    "code": 0,
+    "data": {
+        "minerInfo": {
+            "model": "T3",
+            "sn": "HYT360202C10H12S11B0300211",
+            "minerVersion": "V1.12",
+            "macAddress": "70:69:79:31:1e:80",
+        }
+    },
+}
+
+SUMMARY = {
+    "code": 0,
+    "data": {
+        "summary": [
+            {
+                "pool": "stratum.braiins.com",
+                "poolAlive": "1",
+                "port": "3333",
+                "hrt": "111455.52",
+                "acc": "10900",
+                "rej": "0",
+                "temp": "31|38",
+                "fan": "3524|3583|3583|3613",
+                "voltage": "26.38",
+                "power": "1723.41",
+                "uptime": "98063",
+                "status": "OK",
+                "model": "T3",
+            }
+        ]
+    },
+}
+
+POOLS = {
+    "code": 0,
+    "data": {
+        "pools": [
+            {
+                "url": "stratum2+tcp://stratum.braiins.com:3333/pubkey",
+                "user": "worker",
+                "pass": "123",
+            },
+            {
+                "url": "stratum+tcp://backup.example.com:3333",
+                "user": "worker",
+                "pass": "123",
+            },
+        ]
+    },
+}
+
+
+class TestFluminer(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.miner = FluminerT3("127.0.0.1")
+
+    async def test_summary_data(self):
+        self.assertEqual(
+            await self.miner._get_serial_number(OVERVIEW),
+            OVERVIEW["data"]["minerInfo"]["sn"],
+        )
+        self.assertEqual(await self.miner._get_mac(OVERVIEW), "70:69:79:31:1E:80")
+        self.assertEqual(await self.miner._get_fw_ver(OVERVIEW), "V1.12")
+        self.assertEqual(
+            round(float(await self.miner._get_hashrate(SUMMARY)), 3), 111.456
+        )
+        self.assertEqual(await self.miner._get_wattage(SUMMARY), 1723)
+        self.assertEqual(await self.miner._get_uptime(SUMMARY), 98063)
+        self.assertTrue(await self.miner._is_mining(SUMMARY))
+
+    async def test_fans_and_hashboards(self):
+        fans = await self.miner._get_fans(SUMMARY)
+        self.assertEqual([fan.speed for fan in fans], [3524, 3583, 3583, 3613])
+
+        hashboards = await self.miner._get_hashboards(SUMMARY)
+        self.assertEqual(len(hashboards), 1)
+        self.assertFalse(hashboards[0].missing)
+        self.assertEqual(hashboards[0].temp, 31)
+        self.assertEqual(hashboards[0].chip_temp, 38)
+        self.assertEqual(hashboards[0].expected_chips, 96)
+        self.assertIsNone(hashboards[0].chips)
+        self.assertEqual(hashboards[0].voltage, 26.38)
+
+    async def test_empty_summary_preserves_expected_hashboard_placeholder(self):
+        hashboards = await self.miner._get_hashboards({"code": 0, "data": {}})
+
+        self.assertEqual(len(hashboards), 1)
+        self.assertTrue(hashboards[0].missing)
+        self.assertIsNone(hashboards[0].hashrate)
+
+    async def test_partial_fan_data_preserves_expected_fan_count(self):
+        summary = {
+            **SUMMARY,
+            "data": {"summary": [{**SUMMARY["data"]["summary"][0], "fan": "3524|3583"}]},
+        }
+
+        fans = await self.miner._get_fans(summary)
+
+        self.assertEqual(len(fans), 4)
+        self.assertEqual([fan.speed for fan in fans], [3524, 3583, None, None])
+
+    async def test_pools(self):
+        pools = await self.miner._get_pools(web_summary=SUMMARY, web_pools=POOLS)
+
+        self.assertEqual(len(pools), 2)
+        self.assertTrue(pools[0].active)
+        self.assertTrue(pools[0].alive)
+        self.assertEqual(pools[0].accepted, 10900)
+        self.assertEqual(pools[0].rejected, 0)
+        self.assertFalse(pools[1].active)
+        self.assertIsNone(pools[1].accepted)
+
+    async def test_active_pool_matching_requires_exact_host_and_port(self):
+        pools = await self.miner._get_pools(
+            web_summary=SUMMARY,
+            web_pools={
+                "code": 0,
+                "data": {
+                    "pools": [
+                        {
+                            "url": "stratum+tcp://not-stratum.braiins.com:3333",
+                            "user": "worker",
+                            "pass": "123",
+                        },
+                        {
+                            "url": "stratum+tcp://stratum.braiins.com:333",
+                            "user": "worker",
+                            "pass": "123",
+                        },
+                        {
+                            "url": "stratum+tcp://stratum.braiins.com:3333",
+                            "user": "worker",
+                            "pass": "123",
+                        },
+                    ]
+                },
+            },
+        )
+
+        self.assertEqual([pool.active for pool in pools], [False, False, True])
+
+    async def test_malformed_payloads_return_empty_data(self):
+        self.assertIsNone(await self.miner._get_serial_number({"code": 0, "data": None}))
+        self.assertIsNone(
+            await self.miner._get_hashrate(
+                {"code": 0, "data": {"summary": [None]}}
+            )
+        )
+        self.assertEqual(
+            await self.miner._get_pools(
+                web_summary=SUMMARY,
+                web_pools={
+                    "code": 0,
+                    "data": {
+                        "pools": [
+                            None,
+                            {"url": "not-a-supported-scheme://pool:3333"},
+                            {"url": ""},
+                        ]
+                    },
+                },
+            ),
+            [],
+        )
+
+    async def test_unknown_fluminer_has_no_expected_hashboards(self):
+        miner = Fluminer("127.0.0.1")
+
+        self.assertEqual(await miner._get_hashboards(SUMMARY), [])
+
+    def test_factory_detects_fluminer_before_generic_miner_ui(self):
+        self.assertEqual(
+            MinerFactory._parse_web_type(
+                "<html><title>Fluminer</title>Miner UI</html>",
+                type("Resp", (), {"status_code": 200, "headers": {}, "history": []})(),
+            ),
+            MinerTypes.FLUMINER,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/miners_tests/backends_tests/fluminer_tests.py
+++ b/tests/miners_tests/backends_tests/fluminer_tests.py
@@ -99,7 +99,9 @@ class TestFluminer(unittest.IsolatedAsyncioTestCase):
     async def test_partial_fan_data_preserves_expected_fan_count(self):
         summary = {
             **SUMMARY,
-            "data": {"summary": [{**SUMMARY["data"]["summary"][0], "fan": "3524|3583"}]},
+            "data": {
+                "summary": [{**SUMMARY["data"]["summary"][0], "fan": "3524|3583"}]
+            },
         }
 
         fans = await self.miner._get_fans(summary)
@@ -148,11 +150,11 @@ class TestFluminer(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([pool.active for pool in pools], [False, False, True])
 
     async def test_malformed_payloads_return_empty_data(self):
-        self.assertIsNone(await self.miner._get_serial_number({"code": 0, "data": None}))
         self.assertIsNone(
-            await self.miner._get_hashrate(
-                {"code": 0, "data": {"summary": [None]}}
-            )
+            await self.miner._get_serial_number({"code": 0, "data": None})
+        )
+        self.assertIsNone(
+            await self.miner._get_hashrate({"code": 0, "data": {"summary": [None]}})
         )
         self.assertEqual(
             await self.miner._get_pools(

--- a/tests/miners_tests/backends_tests/fluminer_tests.py
+++ b/tests/miners_tests/backends_tests/fluminer_tests.py
@@ -61,8 +61,6 @@ POOLS = {
 
 
 class TestFluminer(unittest.IsolatedAsyncioTestCase):
-    """Tests for Fluminer T3 data parsing and factory detection."""
-
     def setUp(self):
         self.miner = FluminerT3("127.0.0.1")
 


### PR DESCRIPTION
## Summary
Stock/native firmware support for Fluminer T3 miners.
- Fluminer make/model metadata and `FluminerT3` class wiring
- A read-only Fluminer web API client for native firmware endpoints
- Backend data mapping for hashrate, wattage, fans, two temperature values, uptime, serial/MAC/firmware, pool metrics, and mining status
- Factory detection and model selection for Fluminer dashboards
- Generated miner docs and MkDocs nav entry
