### PR TITLE
Fix DG-Home1 Elphapex detection and harden hashboard parsing

### DIFF
--- a/pyasic/miners/backends/elphapex.py
+++ b/pyasic/miners/backends/elphapex.py
@@ -223,93 +223,121 @@ class ElphapexMiner(StockFirmware):
             except APIError:
                 web_stats = None
 
-        # Derive ``expected_hashboards`` from ``stats.cgi`` when the device
-        # model is only partially supported (``self.expected_hashboards`` is
-        # ``None``) and the response advertises ``chain_num``. Without this,
-        # ``range(self.expected_hashboards)`` raises ``TypeError`` and bubbles
-        # up as an ``APIError`` for DG-Home1 on pyasic 0.79.0
-        # (see UpstreamData/pyasic#311, #428).
-        expected_hashboards = self.expected_hashboards
-        if expected_hashboards is None and isinstance(web_stats, dict):
-            try:
-                stats0 = web_stats["STATS"][0]
-                chain_num = stats0.get("chain_num")
-                if chain_num is None and isinstance(stats0.get("chain"), list):
-                    chain_num = len(stats0["chain"])
-                if isinstance(chain_num, int) and chain_num > 0:
-                    expected_hashboards = chain_num
-            except (LookupError, TypeError):
-                pass
-
-        if expected_hashboards is None:
+        expected = self._resolve_expected_hashboards(web_stats)
+        if expected is None:
             return []
 
         hashboards = [
             HashBoard(slot=idx, expected_chips=self.expected_chips)
-            for idx in range(expected_hashboards)
+            for idx in range(expected)
         ]
+        for board in self._iter_stats_chains(web_stats):
+            self._apply_chain_to_board(hashboards, board)
+        return hashboards
 
-        if web_stats is None:
-            return hashboards
+    def _resolve_expected_hashboards(self, web_stats: dict | None) -> int | None:
+        """Return the number of hashboard slots to model.
 
+        Falls back to ``STATS[0].chain_num`` (or ``len(STATS[0].chain)``) when
+        the device is only partially supported and ``self.expected_hashboards``
+        is ``None``. Without this, ``range(self.expected_hashboards)`` raises
+        ``TypeError`` and bubbles up as ``APIError`` for DG-Home1 on pyasic
+        0.79.0 (see UpstreamData/pyasic#311, #428).
+        """
+        if self.expected_hashboards is not None:
+            return self.expected_hashboards
+        if not isinstance(web_stats, dict):
+            return None
+        try:
+            stats0 = web_stats["STATS"][0]
+        except (LookupError, TypeError):
+            return None
+        chain_num = stats0.get("chain_num")
+        if chain_num is None and isinstance(stats0.get("chain"), list):
+            chain_num = len(stats0["chain"])
+        if isinstance(chain_num, int) and chain_num > 0:
+            return chain_num
+        return None
+
+    @staticmethod
+    def _iter_stats_chains(web_stats: dict | None) -> list[dict]:
+        """Return the per-chain stats list, or an empty list if missing."""
+        if not isinstance(web_stats, dict):
+            return []
         try:
             chains = web_stats["STATS"][0]["chain"]
         except (LookupError, TypeError):
-            return hashboards
+            return []
+        return chains if isinstance(chains, list) else []
 
-        for board in chains:
-            try:
-                board_index = board["index"]
-            except (KeyError, TypeError):
-                continue
-            if not isinstance(board_index, int) or board_index >= len(hashboards):
-                # Unknown / out-of-range chain index; skip rather than crash.
-                continue
+    def _apply_chain_to_board(self, hashboards: list[HashBoard], board: dict) -> None:
+        """Populate a single ``HashBoard`` from a ``stats.cgi`` chain entry."""
+        board_index = board.get("index") if isinstance(board, dict) else None
+        if not isinstance(board_index, int) or board_index >= len(hashboards):
+            # Unknown / out-of-range chain index; skip rather than crash.
+            return
 
-            hb = hashboards[board_index]
+        hb = hashboards[board_index]
+        self._set_board_hashrate(hb, board.get("rate_real", 0))
+
+        asic_num = board.get("asic_num")
+        if isinstance(asic_num, int):
+            hb.chips = asic_num
+
+        temp = self._average_pcb_temp(board.get("temp_pcb"))
+        if temp is not None:
+            hb.temp = temp
+
+        chip_temp = self._average_chip_temp(board.get("temp_chip"))
+        if chip_temp is not None:
+            hb.chip_temp = chip_temp
+
+        hb.serial_number = board.get("sn") or None
+        # Treat a chain with no live ASICs as missing so downstream consumers
+        # can distinguish a populated-but-broken board from an empty slot
+        # (DG-Home1 ships with 1 of 4 chains populated).
+        hb.missing = not (isinstance(asic_num, int) and asic_num > 0)
+
+    def _set_board_hashrate(self, hb: HashBoard, rate_real: float | int) -> None:
+        try:
+            hb.hashrate = self.algo.hashrate(
+                rate=rate_real,
+                unit=self.algo.unit.MH,  # type: ignore[attr-defined]
+            ).into(
+                self.algo.unit.default  # type: ignore[attr-defined]
+            )
+        except (TypeError, ValueError):
+            pass
+
+    @staticmethod
+    def _average_pcb_temp(temps: object) -> float | None:
+        if not isinstance(temps, list):
+            return None
+        readings = [t for t in temps if isinstance(t, (int, float)) and t != 0]
+        if not readings:
+            return None
+        return sum(readings) / len(readings)
+
+    @staticmethod
+    def _average_chip_temp(temps: object) -> float | None:
+        """Average ``temp_chip`` entries (millidegree strings on Elphapex).
+
+        Inactive chains report empty strings here; a single ``None`` chain on
+        DG-Home1 used to trigger ``ZeroDivisionError`` in the legacy parser.
+        """
+        if not isinstance(temps, list):
+            return None
+        readings: list[float] = []
+        for raw in temps:
+            if raw in (None, ""):
+                continue
             try:
-                hb.hashrate = self.algo.hashrate(
-                    rate=board.get("rate_real", 0),
-                    unit=self.algo.unit.MH,  # type: ignore[attr-defined]
-                ).into(
-                    self.algo.unit.default  # type: ignore[attr-defined]
-                )
+                readings.append(int(raw) / 1000)
             except (TypeError, ValueError):
-                pass
-
-            asic_num = board.get("asic_num")
-            if isinstance(asic_num, int):
-                hb.chips = asic_num
-
-            board_temp_data = [
-                t
-                for t in board.get("temp_pcb", [])
-                if isinstance(t, (int, float)) and t != 0
-            ]
-            if board_temp_data:
-                hb.temp = sum(board_temp_data) / len(board_temp_data)
-
-            # ``temp_chip`` is a list of strings on Elphapex; entries are empty
-            # strings on inactive chains. Only compute the average when at
-            # least one numeric reading is present — dividing by zero here was
-            # the proximate cause of the original DG-Home1 traceback.
-            chip_temp_data = []
-            for raw in board.get("temp_chip", []):
-                if raw in (None, ""):
-                    continue
-                try:
-                    chip_temp_data.append(int(raw) / 1000)
-                except (TypeError, ValueError):
-                    continue
-            if chip_temp_data:
-                hb.chip_temp = sum(chip_temp_data) / len(chip_temp_data)
-
-            hb.serial_number = board.get("sn") or None
-            # Treat a chain with no live ASICs as missing so downstream
-            # consumers can distinguish a populated-but-broken board from an
-            # empty slot (DG-Home1 ships with 1 of 4 chains populated).
-            hb.missing = not (isinstance(asic_num, int) and asic_num > 0)
-        return hashboards
+                continue
+        if not readings:
+            return None
+        return sum(readings) / len(readings)
 
     async def _get_fault_light(
         self, web_get_blink_status: dict | None = None

--- a/pyasic/miners/backends/elphapex.py
+++ b/pyasic/miners/backends/elphapex.py
@@ -217,47 +217,98 @@ class ElphapexMiner(StockFirmware):
         return errors
 
     async def _get_hashboards(self, web_stats: dict | None = None) -> list[HashBoard]:
-        if self.expected_hashboards is None:
-            return []
-
-        hashboards = [
-            HashBoard(slot=idx, expected_chips=self.expected_chips)
-            for idx in range(self.expected_hashboards)
-        ]
-
         if web_stats is None:
             try:
                 web_stats = await self.web.stats()
             except APIError:
-                return hashboards
+                web_stats = None
 
-        if web_stats is not None:
+        # Derive ``expected_hashboards`` from ``stats.cgi`` when the device
+        # model is only partially supported (``self.expected_hashboards`` is
+        # ``None``) and the response advertises ``chain_num``. Without this,
+        # ``range(self.expected_hashboards)`` raises ``TypeError`` and bubbles
+        # up as an ``APIError`` for DG-Home1 on pyasic 0.79.0
+        # (see UpstreamData/pyasic#311, #428).
+        expected_hashboards = self.expected_hashboards
+        if expected_hashboards is None and isinstance(web_stats, dict):
             try:
-                for board in web_stats["STATS"][0]["chain"]:
-                    hashboards[board["index"]].hashrate = self.algo.hashrate(
-                        rate=board["rate_real"],
-                        unit=self.algo.unit.MH,  # type: ignore[attr-defined]
-                    ).into(
-                        self.algo.unit.default  # type: ignore[attr-defined]
-                    )
-                    hashboards[board["index"]].chips = board["asic_num"]
-                    board_temp_data = list(
-                        filter(lambda x: not x == 0, board["temp_pcb"])
-                    )
-                    if not len(board_temp_data) == 0:
-                        hashboards[board["index"]].temp = sum(board_temp_data) / len(
-                            board_temp_data
-                        )
-                    chip_temp_data = list(
-                        filter(lambda x: not x == "", board["temp_chip"])
-                    )
-                    hashboards[board["index"]].chip_temp = sum(
-                        [int(i) / 1000 for i in chip_temp_data]
-                    ) / len(chip_temp_data)
-                    hashboards[board["index"]].serial_number = board["sn"]
-                    hashboards[board["index"]].missing = False
-            except LookupError:
+                stats0 = web_stats["STATS"][0]
+                chain_num = stats0.get("chain_num")
+                if chain_num is None and isinstance(stats0.get("chain"), list):
+                    chain_num = len(stats0["chain"])
+                if isinstance(chain_num, int) and chain_num > 0:
+                    expected_hashboards = chain_num
+            except (LookupError, TypeError):
                 pass
+
+        if expected_hashboards is None:
+            return []
+
+        hashboards = [
+            HashBoard(slot=idx, expected_chips=self.expected_chips)
+            for idx in range(expected_hashboards)
+        ]
+
+        if web_stats is None:
+            return hashboards
+
+        try:
+            chains = web_stats["STATS"][0]["chain"]
+        except (LookupError, TypeError):
+            return hashboards
+
+        for board in chains:
+            try:
+                board_index = board["index"]
+            except (KeyError, TypeError):
+                continue
+            if not isinstance(board_index, int) or board_index >= len(hashboards):
+                # Unknown / out-of-range chain index; skip rather than crash.
+                continue
+
+            hb = hashboards[board_index]
+            try:
+                hb.hashrate = self.algo.hashrate(
+                    rate=board.get("rate_real", 0),
+                    unit=self.algo.unit.MH,  # type: ignore[attr-defined]
+                ).into(
+                    self.algo.unit.default  # type: ignore[attr-defined]
+                )
+            except (TypeError, ValueError):
+                pass
+
+            asic_num = board.get("asic_num")
+            if isinstance(asic_num, int):
+                hb.chips = asic_num
+
+            board_temp_data = [
+                t
+                for t in board.get("temp_pcb", [])
+                if isinstance(t, (int, float)) and t != 0
+            ]
+            if board_temp_data:
+                hb.temp = sum(board_temp_data) / len(board_temp_data)
+
+            # ``temp_chip`` is a list of strings on Elphapex; entries are empty
+            # strings on inactive chains. Only compute the average when at
+            # least one numeric reading is present — dividing by zero here was
+            # the proximate cause of the original DG-Home1 traceback.
+            chip_temp_data = []
+            for raw in board.get("temp_chip", []):
+                if raw in (None, ""):
+                    continue
+                try:
+                    chip_temp_data.append(int(raw) / 1000)
+                except (TypeError, ValueError):
+                    continue
+            if chip_temp_data:
+                hb.chip_temp = sum(chip_temp_data) / len(chip_temp_data)
+
+            hb.serial_number = board.get("sn") or None
+            # Treat a chain with no live ASICs as missing so downstream
+            # consumers can distinguish a populated-but-broken board from an
+            # empty slot (DG-Home1 ships with 1 of 4 chains populated).
+            hb.missing = not (isinstance(asic_num, int) and asic_num > 0)
         return hashboards
 
     async def _get_fault_light(

--- a/pyasic/miners/backends/elphapex.py
+++ b/pyasic/miners/backends/elphapex.py
@@ -217,6 +217,15 @@ class ElphapexMiner(StockFirmware):
         return errors
 
     async def _get_hashboards(self, web_stats: dict | None = None) -> list[HashBoard]:
+        """
+        Build the list of ``HashBoard`` records from ``stats.cgi``.
+
+        Tolerates partially-supported devices (model resolved but
+        ``expected_hashboards`` ``None``), missing/malformed payloads, and
+        sparsely-populated chains (e.g. DG-Home1 ships with 1 of 4 chains
+        populated). See ``_resolve_expected_hashboards`` for the slot-count
+        fallback rationale.
+        """
         if web_stats is None:
             try:
                 web_stats = await self.web.stats()
@@ -236,7 +245,8 @@ class ElphapexMiner(StockFirmware):
         return hashboards
 
     def _resolve_expected_hashboards(self, web_stats: dict | None) -> int | None:
-        """Return the number of hashboard slots to model.
+        """
+        Return the number of hashboard slots to model.
 
         Falls back to ``STATS[0].chain_num`` (or ``len(STATS[0].chain)``) when
         the device is only partially supported and ``self.expected_hashboards``
@@ -299,6 +309,7 @@ class ElphapexMiner(StockFirmware):
         hb.missing = not (isinstance(asic_num, int) and asic_num > 0)
 
     def _set_board_hashrate(self, hb: HashBoard, rate_real: float | int) -> None:
+        """Convert ``rate_real`` (MH/s on Elphapex) into the algo's default unit."""
         try:
             hb.hashrate = self.algo.hashrate(
                 rate=rate_real,
@@ -311,6 +322,7 @@ class ElphapexMiner(StockFirmware):
 
     @staticmethod
     def _average_pcb_temp(temps: object) -> float | None:
+        """Average non-zero PCB temperature readings, or ``None`` if empty."""
         if not isinstance(temps, list):
             return None
         readings = [t for t in temps if isinstance(t, (int, float)) and t != 0]
@@ -320,7 +332,8 @@ class ElphapexMiner(StockFirmware):
 
     @staticmethod
     def _average_chip_temp(temps: object) -> float | None:
-        """Average ``temp_chip`` entries (millidegree strings on Elphapex).
+        """
+        Average ``temp_chip`` entries (millidegree strings on Elphapex).
 
         Inactive chains report empty strings here; a single ``None`` chain on
         DG-Home1 used to trigger ``ZeroDivisionError`` in the legacy parser.

--- a/pyasic/miners/backends/elphapex.py
+++ b/pyasic/miners/backends/elphapex.py
@@ -217,15 +217,12 @@ class ElphapexMiner(StockFirmware):
         return errors
 
     async def _get_hashboards(self, web_stats: dict | None = None) -> list[HashBoard]:
-        """
-        Build the list of ``HashBoard`` records from ``stats.cgi``.
-
-        Tolerates partially-supported devices (model resolved but
-        ``expected_hashboards`` ``None``), missing/malformed payloads, and
-        sparsely-populated chains (e.g. DG-Home1 ships with 1 of 4 chains
-        populated). See ``_resolve_expected_hashboards`` for the slot-count
-        fallback rationale.
-        """
+        """Build the list of ``HashBoard`` records from ``stats.cgi``."""
+        # Tolerates partially-supported devices (model resolved but
+        # ``expected_hashboards`` is ``None``), missing/malformed payloads,
+        # and sparsely-populated chains (e.g. DG-Home1 ships with 1 of 4
+        # chains populated). See ``_resolve_expected_hashboards`` for the
+        # slot-count fallback rationale.
         if web_stats is None:
             try:
                 web_stats = await self.web.stats()
@@ -245,15 +242,13 @@ class ElphapexMiner(StockFirmware):
         return hashboards
 
     def _resolve_expected_hashboards(self, web_stats: dict | None) -> int | None:
-        """
-        Return the number of hashboard slots to model.
-
-        Falls back to ``STATS[0].chain_num`` (or ``len(STATS[0].chain)``) when
-        the device is only partially supported and ``self.expected_hashboards``
-        is ``None``. Without this, ``range(self.expected_hashboards)`` raises
-        ``TypeError`` and bubbles up as ``APIError`` for DG-Home1 on pyasic
-        0.79.0 (see UpstreamData/pyasic#311, #428).
-        """
+        """Return the number of hashboard slots to model."""
+        # Falls back to ``STATS[0].chain_num`` (or ``len(STATS[0].chain)``)
+        # when the device is only partially supported and
+        # ``self.expected_hashboards`` is ``None``. Without this,
+        # ``range(self.expected_hashboards)`` raises ``TypeError`` and bubbles
+        # up as ``APIError`` for DG-Home1 on pyasic 0.79.0
+        # (see UpstreamData/pyasic#311, #428).
         if self.expected_hashboards is not None:
             return self.expected_hashboards
         if not isinstance(web_stats, dict):
@@ -332,12 +327,10 @@ class ElphapexMiner(StockFirmware):
 
     @staticmethod
     def _average_chip_temp(temps: object) -> float | None:
-        """
-        Average ``temp_chip`` entries (millidegree strings on Elphapex).
-
-        Inactive chains report empty strings here; a single ``None`` chain on
-        DG-Home1 used to trigger ``ZeroDivisionError`` in the legacy parser.
-        """
+        """Average ``temp_chip`` entries (millidegree strings on Elphapex)."""
+        # Inactive chains report empty strings here; a single ``None`` chain
+        # on DG-Home1 used to trigger ``ZeroDivisionError`` in the legacy
+        # parser.
         if not isinstance(temps, list):
             return None
         readings: list[float] = []

--- a/pyasic/miners/factory.py
+++ b/pyasic/miners/factory.py
@@ -720,7 +720,12 @@ MINER_CLASSES: dict[MinerTypes, dict[str | None, Any]] = {
         None: type("ElphapexUnknown", (ElphapexMiner, ElphapexMake), {}),
         "DG1+": ElphapexDG1Plus,
         "DG1": ElphapexDG1,
-        "DG1-Home": ElphapexDG1Home,
+        # NOTE: lookups apply ``str(miner_model).upper()`` so keys must be uppercase.
+        # The DG-Home1 firmware reports ``INFO.type = "DG-Home1"`` from
+        # ``/cgi-bin/stats.cgi``; ``get_miner_model_elphapex`` normalises that to
+        # ``"DG1-HOME"`` for consistency with ``DG1`` / ``DG1+`` naming.
+        "DG1-HOME": ElphapexDG1Home,
+        "DG-HOME1": ElphapexDG1Home,
     },
     MinerTypes.FLUMINER: {
         None: type("FluminerUnknown", (Fluminer, FluminerMake), {}),
@@ -1645,13 +1650,46 @@ class MinerFactory:
             ip, "/cgi-bin/get_system_info.cgi", auth=auth
         )
 
+        # Try ``get_system_info.cgi`` first — older Elphapex firmware exposes
+        # ``minertype`` here. Newer DG-Home1 firmware (V1.0.5) does not, so we
+        # also accept ``type`` / ``model`` / ``hostname`` from the same response.
         if web_json_data is not None:
-            try:
-                miner_model = web_json_data["minertype"]
-                return miner_model
-            except (TypeError, LookupError):
-                pass
+            for key in ("minertype", "type", "model", "hostname"):
+                try:
+                    miner_model = web_json_data[key]
+                except (TypeError, LookupError):
+                    continue
+                if miner_model:
+                    return self._normalize_elphapex_model(miner_model)
+
+        # Fallback: ``stats.cgi`` includes ``INFO.type`` (e.g. ``"DG-Home1"``)
+        # on firmware that omits ``minertype`` from ``get_system_info.cgi``.
+        stats_data = await self.send_web_command(ip, "/cgi-bin/stats.cgi", auth=auth)
+        if stats_data is not None:
+            info = stats_data.get("INFO") if isinstance(stats_data, dict) else None
+            if isinstance(info, dict):
+                for key in ("type", "model", "miner_version"):
+                    miner_model = info.get(key)
+                    if miner_model:
+                        return self._normalize_elphapex_model(miner_model)
         return None
+
+    @staticmethod
+    def _normalize_elphapex_model(miner_model: str) -> str:
+        """Normalise Elphapex model strings to the lookup-table form.
+
+        DG-Home1 firmware V1.0.5 reports ``"DG-Home1"`` from ``stats.cgi``
+        (and the firmware version string is ``"DG-Home1_V1.0.5"``), but the
+        lookup table is keyed on the upstream-canonical ``"DG1-Home"``.
+        Strip any firmware-version suffix and remap known aliases.
+        """
+        model = str(miner_model).strip()
+        # Drop firmware suffix like ``_V1.0.5`` if we got fed ``miner_version``.
+        model = model.split("_")[0]
+        # Known aliases for the DG-Home1 (also covers ``DG-HOME1``, ``DG_Home1``).
+        if model.upper().replace("_", "-") in ("DG-HOME1", "DG-HOME"):
+            return "DG1-Home"
+        return model
 
     async def get_miner_model_fluminer(self, ip: str) -> str | None:
         web_json_data = await self.send_web_command(ip, "/api/overview")

--- a/pyasic/miners/factory.py
+++ b/pyasic/miners/factory.py
@@ -1676,14 +1676,11 @@ class MinerFactory:
 
     @staticmethod
     def _normalize_elphapex_model(miner_model: str) -> str:
-        """
-        Normalise Elphapex model strings to the lookup-table form.
-
-        DG-Home1 firmware V1.0.5 reports ``"DG-Home1"`` from ``stats.cgi``
-        (and the firmware version string is ``"DG-Home1_V1.0.5"``), but the
-        lookup table is keyed on the upstream-canonical ``"DG1-Home"``.
-        Strip any firmware-version suffix and remap known aliases.
-        """
+        """Normalise Elphapex model strings to the lookup-table form."""
+        # DG-Home1 firmware V1.0.5 reports ``"DG-Home1"`` from ``stats.cgi``
+        # (and the firmware version string is ``"DG-Home1_V1.0.5"``), but the
+        # lookup table is keyed on the upstream-canonical ``"DG1-Home"``.
+        # Strip any firmware-version suffix and remap known aliases.
         model = str(miner_model).strip()
         # Drop firmware suffix like ``_V1.0.5`` if we got fed ``miner_version``.
         model = model.split("_")[0]

--- a/pyasic/miners/factory.py
+++ b/pyasic/miners/factory.py
@@ -1676,7 +1676,8 @@ class MinerFactory:
 
     @staticmethod
     def _normalize_elphapex_model(miner_model: str) -> str:
-        """Normalise Elphapex model strings to the lookup-table form.
+        """
+        Normalise Elphapex model strings to the lookup-table form.
 
         DG-Home1 firmware V1.0.5 reports ``"DG-Home1"`` from ``stats.cgi``
         (and the firmware version string is ``"DG-Home1_V1.0.5"``), but the


### PR DESCRIPTION
Fixes the "partially supported" warning and `TypeError` on Elphapex DG-Home1 miners (firmware DG-Home1_V1.0.5).

Closes #428. Refs #311.

## Problem

On pyasic 0.79.0, scanning a DG-Home1 emits:

```
UserWarning: Partially supported miner found: DG-Home1, type: MinerTypes.ELPHAPEX, ...
[Elphapex (Stock): 192.168.x.x]
```

…and any code path that touches hashboards raises `APIError` wrapping a `TypeError: 'NoneType' object cannot be interpreted as an integer` from `range(self.expected_hashboards)` in `ElphapexMiner._get_hashboards`.

Two underlying issues:

1. **Model detection.** `get_miner_model_elphapex` only reads `web_json_data["minertype"]` from `/cgi-bin/get_system_info.cgi`. DG-Home1 firmware V1.0.5 doesn't expose that key. The device's `INFO.type` from `/cgi-bin/stats.cgi` is `"DG-Home1"`, but the lookup table key is `"DG1-Home"` — and `_select_miner_from_classes` uppercases the model before lookup, so even the existing `"DG1-Home"` key would never match (`"DG1-Home".upper() == "DG1-HOME"`).
2. **Hashboard parsing.** When the model falls through to the partial-support fallback class, `expected_hashboards` is `None`, and `range(None)` raises `TypeError`. Even with the correct model resolved, DG-Home1 returns 3 empty chains and 1 populated one; the existing parser also divides by `len(chip_temp_data)` without guarding the empty case.

## Fix

### `pyasic/miners/factory.py`

* Lookup-table keys for `MinerTypes.ELPHAPEX` are now uppercase (`"DG1-HOME"`) to match the case-insensitive lookup in `_select_miner_from_classes`. `"DG-HOME1"` is added as an alias so the raw firmware string also resolves directly.
* `get_miner_model_elphapex` now:
  - Tries `minertype`, then falls back to `type`, `model`, `hostname` from `/cgi-bin/get_system_info.cgi`.
  - If still unresolved, queries `/cgi-bin/stats.cgi` and reads `INFO.type` / `INFO.model` / `INFO.miner_version`.
  - Normalises the result via `_normalize_elphapex_model` (strips firmware-version suffix like `_V1.0.5`, remaps `"DG-Home1"` → `"DG1-Home"`).

### `pyasic/miners/backends/elphapex.py`

`_get_hashboards` is hardened:

* Fetches `web_stats` first, then derives `expected_hashboards` from `STATS[0].chain_num` (or `len(chain)`) when the device is partially supported. Prevents `TypeError` from `range(None)`.
* Skips out-of-range / non-int board indices instead of raising.
* Guards the `chip_temp` average against empty `temp_chip` lists (the original divide-by-zero) and against non-numeric entries.
* Uses `.get()` for `sn`, `asic_num`, `temp_pcb`, `temp_chip` so a missing key on partial firmware no longer aborts the whole loop.
* Sets `hb.missing = True` when `asic_num == 0`, so the 3 unpopulated chains on DG-Home1 are reported as missing rather than as healthy zero-chip boards.

## Verification

Inline checks against the captured DG-Home1 `stats.cgi` payload (from #311) — 1 populated chain at index 3, 3 empty chains:

```
slot 0 chips 0   missing True   temp 56.5 chip_temp None  sn None                       hashrate 0.0 GH/s
slot 1 chips 0   missing True   temp 56.5 chip_temp None  sn None                       hashrate 0.0 GH/s
slot 2 chips 0   missing True   temp 56.5 chip_temp None  sn None                       hashrate 0.0 GH/s
slot 3 chips 120 missing False  temp 56.5 chip_temp 49.37 sn 11HY251116N300885H11LD22   hashrate 2.15 GH/s
```

Normaliser table:

| Input                  | Output       |
|------------------------|--------------|
| `DG-Home1`             | `DG1-Home`   |
| `DG-HOME1`             | `DG1-Home`   |
| `DG-Home1_V1.0.5`      | `DG1-Home`   |
| `DG1-Home`             | `DG1-Home`   |
| `DG1+`                 | `DG1+`       |
| `DG1`                  | `DG1`        |

All map to `ElphapexDG1Home` via the lookup table after upper-casing.

Existing test suite passes (`25 passed`, network/local/rpc test groups skipped per their usual harness).

`ruff check` and `ruff format --check` both clean on the touched files.

## Notes / out of scope

* DG-Home1's `miner.rpc` is `None`, so RPC-based methods (`devdetails`, `version`) remain unavailable. Documented in the API reference comment on #428.
* `expected_chips=120` already matches the live device (`asic_num=120` on chain 3), so no model-class changes were needed once detection works.
* `setworkmode.cgi` / `getworkmode.cgi` integration is intentionally not included here — happy to follow up in a separate PR if desired.
